### PR TITLE
リリースCIの重複manifestを除外

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: pnpm test
       - name: Build
         run: pnpm build
+      - name: Remove Vite manifest
+        run: rm -f dist/.vite/manifest.json
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## 概要
Release添付時に重複する manifest.json が原因で失敗するのを防止する

## 変更点
- dist/.vite/manifest.json を削除して重複アップロードを回避

## 影響・補足
- Release添付に含めるファイル数が1件減る
