### PR TITLE
リリース成果物をZIP化

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -30,9 +30,9 @@ jobs:
         run: pnpm test
       - name: Build
         run: pnpm build
-      - name: Remove Vite manifest
-        run: rm -f dist/.vite/manifest.json
+      - name: Create release zip
+        run: zip -r "chrome-tab-manager-v${{ github.ref_name }}.zip" dist
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/**
+          files: chrome-tab-manager-v${{ github.ref_name }}.zip


### PR DESCRIPTION
## 概要
Release添付をZIPにまとめるように変更する

## 変更点
- dist を chrome-tab-manager-v${tag}.zip に圧縮して添付
- 個別ファイルのアップロードを廃止

## 影響・補足
- Releaseの添付はZIPのみになる
