### PR TITLE
docs: READMEとAGENTSを現行構成へ更新

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,22 @@
 
 ## プロジェクト構成 / モジュール構成
 
-- ルート設定: `manifest.json`, `popup.html`, `vite.config.ts`, `tsconfig.json`, `eslint.config.js`
-- ソースコードは `src/popup/`（React のポップアップ UI）
-  - エントリ: `src/popup/main.tsx`
-  - アプリシェル: `src/popup/App.tsx`
-  - スタイル: `src/popup/popup.css`
-  - ユーティリティ: `src/popup/title.ts`
-- テスト: `src/popup/__tests__/`（Vitest）
+- ルート設定: `manifest.json`, `manager.html`, `options.html`, `vite.config.ts`, `tsconfig.json`, `eslint.config.ts`
+- ソースコード
+  - `src/background/`: Service Worker（アクションクリック / コンテキストメニュー処理）
+    - エントリ: `src/background/main.ts`
+  - `src/manager/`: 管理画面 UI（保存済みウィンドウの検索・復元・並び替え）
+    - エントリ: `src/manager/main.tsx`
+    - アプリ: `src/manager/ManagerApp.tsx`
+    - スタイル: `src/manager/manager.css`
+  - `src/options/`: オプション画面 UI（復元設定・除外ルール・テーマ）
+    - エントリ: `src/options/main.tsx`
+    - アプリ: `src/options/OptionsApp.tsx`
+    - スタイル: `src/options/options.css`
+  - `src/tab-manager/`: 状態管理・履歴・フィルタなどのドメインロジック
+  - `src/components/`: 共通 UI コンポーネント
+  - `src/theme/`: テーマ解決ロジック
+- テスト: 各モジュール配下の `*.test.ts`（Vitest）
 - 静的アセット: `public/icons/`（拡張アイコン）
 - ビルド出力: `dist/`
 
@@ -16,7 +25,7 @@
 
 コマンドはすべて `pnpm` を使用すること。
 
-- `pnpm dev`: ポップアップ UI の Vite dev サーバを起動
+- `pnpm dev`: Vite dev サーバを起動（拡張機能の UI 開発）
 - `pnpm build`: 型チェック後に本番ビルド（`tsc && vite build`）
 - `pnpm preview`: 本番ビルドのプレビュー
 - `pnpm test`: Vitest でユニットテスト実行
@@ -31,21 +40,21 @@
 
 - Prettier が唯一の正とする: シングルクォート、セミコロン、末尾カンマ、100文字幅
 - インデントは Prettier のデフォルト（2スペース）
-- React コンポーネントは PascalCase（例: `App.tsx`）、関数/変数は camelCase
-- ポップアップ UI のロジックは `src/popup/` に集約し、フォルダ横断の結合を避ける
+- React コンポーネントは PascalCase（例: `ManagerApp.tsx`）、関数/変数は camelCase
+- UI は `src/manager/` と `src/options/` に分離し、状態ロジックは `src/tab-manager/` に集約する
 
 ## 開発アプローチ（TDD）
 
 - RED → GREEN → REFACTOR を厳守（失敗テスト → 最小実装 → リファクタ）
 - 単一責務・小さな単位を維持し、テスト容易性のため依存を明示する
-- 新規フォルダ追加時はテストをコロケーションする（既存テストは `src/popup/__tests__/`）
+- 新規モジュール追加時はコロケーションした `*.test.ts` を追加する
 - PR 前に品質チェック（`pnpm lint`, `pnpm format`, `pnpm typecheck`, `pnpm test`）を行う
 
 ## テストガイドライン
 
 - テストフレームワーク: Vitest
-- 置き場所: `src/popup/__tests__/`
-- 命名: `*.test.ts`（例: `title.test.ts`）
+- 置き場所: 対象ファイルと同一ディレクトリ（例: `src/manager/*.test.ts`）
+- 命名: `*.test.ts`（例: `lockState.test.ts`）
 - ロジック変更時は `pnpm test` を実行する
 
 ## コミット / PR ガイドライン

--- a/README.md
+++ b/README.md
@@ -1,0 +1,116 @@
+# Chrome Tab Manager
+
+Chrome のタブを「保存して閉じる」し、あとでまとめて復元できる拡張機能です。  
+保存済みタブはセット（ウィンドウ単位）として管理し、検索・フィルタ・ロック・並び替えに対応しています。
+
+## 主な機能
+
+- ツールバーアイコンのクリックで、現在ウィンドウのタブを保存して閉じる
+- 拡張機能メニュー（アクションメニュー）から次の操作を実行可能
+  - タブマネージャーを開く
+  - タブを保存して閉じる（現在ウィンドウ）
+  - 今開いているタブを保存して閉じる（アクティブタブ）
+  - 今開いているグループを保存して閉じる
+- 保存済みウィンドウ（セット）の一覧表示
+  - タイトル / URL 検索
+  - セット単位・グループ単位フィルタ
+- 復元操作
+  - セット全体、グループ単位、タブ単位で復元
+  - 新規ウィンドウの作成
+- 管理機能
+  - セット・グループ・タブのロック
+  - セット / グループ / タブのドラッグ&ドロップ並び替え
+  - セット名・グループ名の編集
+  - タブ情報の再取得
+- オプション画面
+  - 復元時の読み込み抑制
+  - 復元済みタブを履歴から削除
+  - 除外ルール（URL プレフィックス / ドメイン）
+  - テーマ（システム準拠 / ライト / ダーク）
+
+## 画面
+
+- 管理画面: `manager.html`
+- オプション画面: `options.html`
+
+## 導入方法
+
+### 1. Release から ZIP を取得して使う
+
+1. GitHub の [Releases](https://github.com/yone/chrome-tab-manager/releases) から `chrome-tab-manager-vx.y.z.zip` をダウンロード
+2. ZIP を展開し、展開先の `chrome-tab-manager` ディレクトリを確認
+3. Chrome で `chrome://extensions` を開く
+4. 右上の「デベロッパーモード」を有効化
+5. 「パッケージ化されていない拡張機能を読み込む」で、手順2の `chrome-tab-manager` ディレクトリを選択
+
+### 2. リポジトリを Clone して build して使う
+
+1. リポジトリを取得
+
+```bash
+git clone https://github.com/yone/chrome-tab-manager.git
+cd chrome-tab-manager
+```
+
+2. 依存関係をインストール
+
+```bash
+pnpm install
+```
+
+3. ビルド
+
+```bash
+pnpm build
+```
+
+4. Chrome で読み込む（開発者モード）
+
+- Chrome で `chrome://extensions` を開く
+- 右上の「デベロッパーモード」を有効化
+- Clone + build の場合は `dist` ディレクトリが生成されるので、それを選択
+
+## 開発コマンド
+
+- `pnpm dev`: Vite 開発サーバーを起動
+- `pnpm build`: 型チェック後に本番ビルド（`tsc && vite build`）
+- `pnpm preview`: 本番ビルドをプレビュー
+- `pnpm test`: Vitest テスト実行
+- `pnpm lint`: ESLint 実行
+- `pnpm format`: Prettier 実行
+- `pnpm typecheck`: TypeScript 型チェック
+- `pnpm check`: `lint + format + typecheck`
+
+## データ保存と権限
+
+- 状態は `chrome.storage.local` に保存
+- 主な権限: `storage`, `tabs`, `tabGroups`, `contextMenus`
+
+## プロジェクト構成
+
+```text
+.
+├─ src/background/   # Service Worker（アクション・コンテキストメニュー処理）
+├─ src/manager/      # 管理画面（保存済みウィンドウの操作 UI）
+├─ src/options/      # オプション画面
+├─ src/tab-manager/  # 状態管理・履歴・除外ルールなどのドメインロジック
+├─ src/components/   # 共通 UI コンポーネント
+├─ src/theme/        # テーマ解決ロジック
+├─ manager.html
+├─ options.html
+└─ manifest.json
+```
+
+## 品質チェック手順
+
+変更時は以下の順で確認してください。
+
+```bash
+pnpm test
+pnpm check
+pnpm build
+```
+
+## ライセンス
+
+[MIT](./LICENSE)


### PR DESCRIPTION
## 概要
READMEの導入手順を実際の配布形態に合わせて整理し、AGENTS.mdのプロジェクト構成説明を現状コードに合わせて更新しました。

## 変更点
- READMEに「Release ZIP」と「Clone + build」の2つの導入フローを分けて記載
- Release ZIPでは`dist`が生成されず、展開した`chrome-tab-manager`を読み込む点を明記
- AGENTS.mdの構成説明を`src/background`/`src/manager`/`src/options`/`src/tab-manager`中心へ更新

## 影響・補足
- 変更はドキュメントのみで、アプリ挙動への影響はありません
- 動作確認として `pnpm test` / `pnpm check` / `pnpm build` を実行済みです
