### PR TITLE
バージョンを1.1.1に更新

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chrome Tab Manager",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "タブ管理拡張機能",
   "action": {
     "default_title": "Tab Manager"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chrome-tab-manager",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 概要
メンテナンスバージョンを1つ上げ、リリース番号を更新しました。

## 変更点
- `manifest.json` の `version` を `1.1.0` から `1.1.1` に更新
- `package.json` の `version` を `1.1.0` から `1.1.1` に更新

## 影響・補足
- 変更はバージョン情報のみです
