### PR TITLE
feat: リンク中ウィンドウセットカードの視覚的強調

### DIFF
--- a/src/manager/ManagerApp.tsx
+++ b/src/manager/ManagerApp.tsx
@@ -85,6 +85,7 @@ import { computeDropGapPx, DEFAULT_DROP_GAP_PX } from './dropGap';
 import { selectDragItemHeight } from './dragHeight';
 import { resolveScrollFadeState } from './scrollFade';
 import { useCardResize } from './useCardResize';
+import { resolveCardClassName } from './cardClass';
 import './manager.css';
 
 type LoadState = 'loading' | 'ready' | 'error';
@@ -342,13 +343,13 @@ function OverlayUngroupedTabBlock({ tab }: { tab: TabSnapshot }) {
   );
 }
 
-function OverlaySetCard({ set }: { set: HistorySet }) {
+function OverlaySetCard({ set, isBoundCurrent }: { set: HistorySet; isBoundCurrent: boolean }) {
   const totalTabs = set.tabs.length;
   const tabSummary = `保存済みタブ: ${totalTabs}件`;
   const layoutEntries = buildLayoutEntries(set);
 
   return (
-    <article className="manager__card manager__card--overlay">
+    <article className={`${resolveCardClassName(false, isBoundCurrent)} manager__card--overlay`}>
       <div className="manager__card-header">
         <div className="manager__card-header-main">
           <OverlayHandle />
@@ -1177,7 +1178,7 @@ function SetCard({
   return (
     <article
       ref={setDragRef}
-      className={`manager__card${isDragging ? ' manager__card--dragging' : ''}`}
+      className={resolveCardClassName(isDragging, isBoundCurrent)}
       style={cardHeight !== null ? { height: `${cardHeight}px` } : undefined}
     >
       <div className="manager__card-header">
@@ -1852,9 +1853,11 @@ export function ManagerApp() {
     if (dragItem.type === 'set') {
       const set = fullSets.find((item) => item.id === dragItem.setId);
       if (set) {
+        const overlayBoundCurrent =
+          resolveBindingStatus(set.managerBinding, currentManagerContext) === 'bound-current';
         return (
           <div className="manager__drag-overlay">
-            <OverlaySetCard set={set} />
+            <OverlaySetCard set={set} isBoundCurrent={overlayBoundCurrent} />
           </div>
         );
       }
@@ -1890,7 +1893,7 @@ export function ManagerApp() {
         <span className="manager__drag-label">{dragLabel}</span>
       </div>
     );
-  }, [activeDrag, fullSets]);
+  }, [activeDrag, fullSets, currentManagerContext]);
 
   const setOptions = useMemo(() => {
     if (state.status !== 'ready' || !state.data) {

--- a/src/manager/cardClass.test.ts
+++ b/src/manager/cardClass.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCardClassName } from './cardClass';
+
+describe('resolveCardClassName', () => {
+  it('returns base class by default', () => {
+    expect(resolveCardClassName(false, false)).toBe('manager__card');
+  });
+
+  it('appends --dragging when isDragging is true', () => {
+    expect(resolveCardClassName(true, false)).toBe('manager__card manager__card--dragging');
+  });
+
+  it('appends --linked when isBoundCurrent is true', () => {
+    expect(resolveCardClassName(false, true)).toBe('manager__card manager__card--linked');
+  });
+
+  it('appends both --dragging and --linked when both are true', () => {
+    expect(resolveCardClassName(true, true)).toBe(
+      'manager__card manager__card--dragging manager__card--linked',
+    );
+  });
+});

--- a/src/manager/cardClass.ts
+++ b/src/manager/cardClass.ts
@@ -1,0 +1,6 @@
+export function resolveCardClassName(isDragging: boolean, isBoundCurrent: boolean): string {
+  let className = 'manager__card';
+  if (isDragging) className += ' manager__card--dragging';
+  if (isBoundCurrent) className += ' manager__card--linked';
+  return className;
+}

--- a/src/manager/manager.css
+++ b/src/manager/manager.css
@@ -18,6 +18,9 @@
   --tm-overlay-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
   --tm-handle-line: #64748b;
   --tm-error: #b91c1c;
+  --tm-linked-border: #15803d;
+  --tm-linked-bg: rgba(34, 197, 94, 0.08);
+  --tm-linked-fade: #f2faf5;
 
   --tm-button-primary-bg: #0f172a;
   --tm-button-primary-text: #fff;
@@ -48,6 +51,9 @@
   --tm-overlay-shadow: 0 24px 44px rgba(2, 6, 23, 0.55);
   --tm-handle-line: #94a3b8;
   --tm-error: #f87171;
+  --tm-linked-border: #15803d;
+  --tm-linked-bg: rgba(74, 222, 128, 0.1);
+  --tm-linked-fade: #152019;
 
   --tm-button-primary-bg: #3b82f6;
   --tm-button-primary-text: #0b1220;
@@ -197,6 +203,12 @@ body {
   gap: 6px;
 }
 
+.manager__card--linked {
+  border-color: var(--tm-linked-border);
+  background: var(--tm-linked-bg);
+  --tm-card-fade: var(--tm-linked-fade);
+}
+
 .manager__card-body-shell {
   min-height: 0;
   position: relative;
@@ -231,8 +243,8 @@ body {
   top: 0;
   background: linear-gradient(
     to bottom,
-    var(--tm-surface),
-    color-mix(in srgb, var(--tm-surface) 0%, transparent)
+    var(--tm-card-fade, var(--tm-surface)),
+    color-mix(in srgb, var(--tm-card-fade, var(--tm-surface)) 0%, transparent)
   );
 }
 
@@ -240,8 +252,8 @@ body {
   bottom: 0;
   background: linear-gradient(
     to top,
-    var(--tm-surface),
-    color-mix(in srgb, var(--tm-surface) 0%, transparent)
+    var(--tm-card-fade, var(--tm-surface)),
+    color-mix(in srgb, var(--tm-card-fade, var(--tm-surface)) 0%, transparent)
   );
 }
 


### PR DESCRIPTION
## Summary
- `bound-current`（この管理画面に接続中）状態のウィンドウセットカードに緑色のボーダーと薄い緑背景を適用し、リンク状態を一目で判別できるようにした
- `resolveCardClassName` ヘルパー関数を新規作成し、インラインのクラス名生成ロジックを集約
- スクロールフェードのグラデーション色をlinked背景に追従させ、ドラッグオーバーレイにもlinked状態を反映

Closes #15

## Test plan
- [x] `pnpm test` - 169テスト全パス（`cardClass.test.ts` の4ケース含む）
- [x] `pnpm check` - lint, format, typecheck 全パス
- [x] `pnpm build` - 本番ビルド成功
- [ ] 手動確認: ライト/ダーク両テーマでリンク済みカードの緑ボーダー＋薄緑背景が表示される
- [ ] 手動確認: ドラッグ中もlinkedインジケータが維持される
- [ ] 手動確認: タブ数が多いカードでスクロールフェードがlinked背景と一致する