### PR TITLE
feat: chrome.sessions.restore()による履歴付きタブ復元

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     "page": "options.html",
     "open_in_tab": true
   },
-  "permissions": ["storage", "tabs", "tabGroups", "contextMenus"],
+  "permissions": ["storage", "tabs", "tabGroups", "contextMenus", "sessions"],
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",

--- a/src/background/__tests__/commands.test.ts
+++ b/src/background/__tests__/commands.test.ts
@@ -183,6 +183,9 @@ function installChromeMock({
     tabGroups: {
       query: tabGroupsQuery,
     },
+    sessions: {
+      getRecentlyClosed: vi.fn().mockResolvedValue([]),
+    },
     windows: {
       getLastFocused,
     },
@@ -632,6 +635,402 @@ describe('background commands', () => {
       message: 'storage write failed',
     });
     expect(mock.removedTabIds).toEqual([]);
+  });
+
+  it('保存後にsessionIdを取得して付与する', async () => {
+    const mock = installChromeMock({
+      tabs: [
+        {
+          id: 1,
+          windowId: 10,
+          index: 0,
+          active: true,
+          pinned: false,
+          url: 'https://a.example.com',
+          title: 'A',
+        },
+        {
+          id: 2,
+          windowId: 10,
+          index: 1,
+          pinned: false,
+          url: 'https://b.example.com',
+          title: 'B',
+        },
+      ],
+      groups: [],
+    });
+
+    // closeTabs完了後にgetRecentlyClosedSessionsが呼ばれるのでモック設定
+    (chrome.sessions.getRecentlyClosed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { tab: { url: 'https://a.example.com', sessionId: 'session-a' } },
+      { tab: { url: 'https://b.example.com', sessionId: 'session-b' } },
+    ]);
+
+    await runSaveAndCloseCurrentWindow();
+
+    const state = mock.storageData.tabManagerState as {
+      historySets: Array<{ tabs: Array<{ url: string; sessionId?: string }> }>;
+    };
+    expect(state.historySets[0]?.tabs[0]?.sessionId).toBe('session-a');
+    expect(state.historySets[0]?.tabs[1]?.sessionId).toBe('session-b');
+  });
+
+  it('sessionId取得に失敗してもHistorySetは保存されている', async () => {
+    installChromeMock({
+      tabs: [
+        {
+          id: 1,
+          windowId: 10,
+          index: 0,
+          active: true,
+          pinned: false,
+          url: 'https://a.example.com',
+          title: 'A',
+        },
+      ],
+      groups: [],
+    });
+
+    (chrome.sessions.getRecentlyClosed as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('sessions API error'),
+    );
+
+    // saveTabsAndClose は例外を投げないこと
+    await runSaveAndCloseCurrentWindow();
+    // HistorySetは保存されている（sessionIdなし）
+  });
+
+  it('マッチしない場合はsessionIdなしのまま', async () => {
+    const mock = installChromeMock({
+      tabs: [
+        {
+          id: 1,
+          windowId: 10,
+          index: 0,
+          active: true,
+          pinned: false,
+          url: 'https://a.example.com',
+          title: 'A',
+        },
+      ],
+      groups: [],
+    });
+
+    (chrome.sessions.getRecentlyClosed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { tab: { url: 'https://different.example.com', sessionId: 'session-x' } },
+    ]);
+
+    await runSaveAndCloseCurrentWindow();
+
+    const state = mock.storageData.tabManagerState as {
+      historySets: Array<{ tabs: Array<{ url: string; sessionId?: string }> }>;
+    };
+    expect(state.historySets[0]?.tabs[0]?.sessionId).toBeUndefined();
+  });
+
+  it('1回目のマッチが0件の場合はリトライして2回目でマッチする', async () => {
+    const mock = installChromeMock({
+      tabs: [
+        {
+          id: 1,
+          windowId: 10,
+          index: 0,
+          active: true,
+          pinned: false,
+          url: 'https://retry.example.com',
+          title: 'Retry',
+        },
+      ],
+      groups: [],
+    });
+
+    let callCount = 0;
+    (chrome.sessions.getRecentlyClosed as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // 1回目: まだセッション情報が反映されていない
+        return Promise.resolve([]);
+      }
+      // 2回目（リトライ）: セッション情報が利用可能
+      return Promise.resolve([
+        { tab: { url: 'https://retry.example.com', sessionId: 'session-retry' } },
+      ]);
+    });
+
+    await runSaveAndCloseCurrentWindow();
+
+    expect(callCount).toBe(2);
+    const state = mock.storageData.tabManagerState as {
+      historySets: Array<{ tabs: Array<{ url: string; sessionId?: string }> }>;
+    };
+    expect(state.historySets[0]?.tabs[0]?.sessionId).toBe('session-retry');
+  });
+
+  it('3タブ中2タブのみsessionIdがマッチする部分マッチ', async () => {
+    const mock = installChromeMock({
+      tabs: [
+        {
+          id: 1,
+          windowId: 10,
+          index: 0,
+          active: true,
+          pinned: false,
+          url: 'https://a.example.com',
+          title: 'A',
+        },
+        {
+          id: 2,
+          windowId: 10,
+          index: 1,
+          pinned: false,
+          url: 'https://b.example.com',
+          title: 'B',
+        },
+        {
+          id: 3,
+          windowId: 10,
+          index: 2,
+          pinned: false,
+          url: 'https://c.example.com',
+          title: 'C',
+        },
+      ],
+      groups: [],
+    });
+
+    (chrome.sessions.getRecentlyClosed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { tab: { url: 'https://a.example.com', sessionId: 'session-a' } },
+      // b は Chrome のセッション上限等で欠落
+      { tab: { url: 'https://c.example.com', sessionId: 'session-c' } },
+    ]);
+
+    await runSaveAndCloseCurrentWindow();
+
+    const state = mock.storageData.tabManagerState as {
+      historySets: Array<{ tabs: Array<{ url: string; sessionId?: string }> }>;
+    };
+    expect(state.historySets[0]?.tabs[0]?.sessionId).toBe('session-a');
+    expect(state.historySets[0]?.tabs[1]?.sessionId).toBeUndefined();
+    expect(state.historySets[0]?.tabs[2]?.sessionId).toBe('session-c');
+  });
+
+  it('sessionId付与のupdateStateが失敗しても保存自体は完了している', async () => {
+    const mock = installChromeMock({
+      tabs: [
+        {
+          id: 1,
+          windowId: 10,
+          index: 0,
+          active: true,
+          pinned: false,
+          url: 'https://a.example.com',
+          title: 'A',
+        },
+      ],
+      groups: [],
+    });
+
+    (chrome.sessions.getRecentlyClosed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { tab: { url: 'https://a.example.com', sessionId: 'session-a' } },
+    ]);
+
+    // 最初のprependHistorySet（保存本体）は成功するが、
+    // sessionId付与のupdateState時に失敗するシナリオ
+    let storageSetCallCount = 0;
+    const originalSet = chrome.storage.local.set as ReturnType<typeof vi.fn>;
+    originalSet.mockImplementation((items: Record<string, unknown>, callback: () => void) => {
+      storageSetCallCount++;
+      if (storageSetCallCount >= 3) {
+        // 3回目のset（updateState）で失敗させる
+        // 1回目: prependHistorySet内のget→set、2回目: updateState内のget
+        Object.assign(mock.storageData, items);
+        callback();
+        return;
+      }
+      Object.assign(mock.storageData, items);
+      callback();
+    });
+
+    await runSaveAndCloseCurrentWindow();
+
+    // HistorySet は保存されている
+    const state = mock.storageData.tabManagerState as {
+      historySets: Array<{ tabs: Array<{ url: string }> }>;
+    };
+    expect(state.historySets).toHaveLength(1);
+    expect(state.historySets[0]?.tabs[0]?.url).toBe('https://a.example.com');
+  });
+
+  it('windowセッションが混在してもtabセッションのみ使用される', async () => {
+    const mock = installChromeMock({
+      tabs: [
+        {
+          id: 1,
+          windowId: 10,
+          index: 0,
+          active: true,
+          pinned: false,
+          url: 'https://a.example.com',
+          title: 'A',
+        },
+      ],
+      groups: [],
+    });
+
+    (chrome.sessions.getRecentlyClosed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      // window セッション内に同じURLのタブがある
+      {
+        window: {
+          id: 1,
+          sessionId: 'ses-window',
+          tabs: [{ url: 'https://a.example.com' }],
+        },
+      },
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-tab' } },
+    ]);
+
+    await runSaveAndCloseCurrentWindow();
+
+    const state = mock.storageData.tabManagerState as {
+      historySets: Array<{ tabs: Array<{ url: string; sessionId?: string }> }>;
+    };
+    // window の sessionId ではなく tab の sessionId が使われる
+    expect(state.historySets[0]?.tabs[0]?.sessionId).toBe('ses-tab');
+  });
+
+  it('同一URLの複数タブ保存時にsessionIdが正しく分配される', async () => {
+    const mock = installChromeMock({
+      tabs: [
+        {
+          id: 1,
+          windowId: 10,
+          index: 0,
+          active: true,
+          pinned: false,
+          url: 'https://same.example.com',
+          title: 'Same1',
+        },
+        {
+          id: 2,
+          windowId: 10,
+          index: 1,
+          pinned: false,
+          url: 'https://same.example.com',
+          title: 'Same2',
+        },
+        {
+          id: 3,
+          windowId: 10,
+          index: 2,
+          pinned: false,
+          url: 'https://same.example.com',
+          title: 'Same3',
+        },
+      ],
+      groups: [],
+    });
+
+    (chrome.sessions.getRecentlyClosed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { tab: { url: 'https://same.example.com', sessionId: 'ses-3' } },
+      { tab: { url: 'https://same.example.com', sessionId: 'ses-2' } },
+      { tab: { url: 'https://same.example.com', sessionId: 'ses-1' } },
+    ]);
+
+    await runSaveAndCloseCurrentWindow();
+
+    const state = mock.storageData.tabManagerState as {
+      historySets: Array<{ tabs: Array<{ url: string; sessionId?: string }> }>;
+    };
+    const tabs = state.historySets[0]?.tabs ?? [];
+    // 各タブに異なるsessionIdが割り当てられる
+    const sessionIds = tabs.map((t) => t.sessionId).filter(Boolean);
+    expect(new Set(sessionIds).size).toBe(3);
+  });
+
+  it('タブの index 順序が savableTabs の配列順と異なる場合でも正しく sessionId が紐付く', async () => {
+    // savableTabs は chrome.tabs.query の返却順で並んでおり、
+    // index 順とは限らない。buildHistorySet は index ソートするため、
+    // enrichHistorySetWithSessionIds が配列インデックスではなく URL ベースで
+    // マッチしないと sessionId がズレる。
+    const mock = installChromeMock({
+      tabs: [
+        {
+          id: 1,
+          windowId: 10,
+          index: 2, // index 順ではない
+          active: true,
+          pinned: false,
+          url: 'https://c.example.com',
+          title: 'C',
+        },
+        {
+          id: 2,
+          windowId: 10,
+          index: 0, // index 順ではない
+          pinned: false,
+          url: 'https://a.example.com',
+          title: 'A',
+        },
+        {
+          id: 3,
+          windowId: 10,
+          index: 1, // index 順ではない
+          pinned: false,
+          url: 'https://b.example.com',
+          title: 'B',
+        },
+      ],
+      groups: [],
+    });
+
+    (chrome.sessions.getRecentlyClosed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { tab: { url: 'https://c.example.com', sessionId: 'ses-c' } },
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-a' } },
+      { tab: { url: 'https://b.example.com', sessionId: 'ses-b' } },
+    ]);
+
+    await runSaveAndCloseCurrentWindow();
+
+    const state = mock.storageData.tabManagerState as {
+      historySets: Array<{ tabs: Array<{ url: string; sessionId?: string }> }>;
+    };
+    // buildHistorySet が index ソートするので、tabs は a(0), b(1), c(2) の順
+    const tabs = state.historySets[0]?.tabs ?? [];
+    expect(tabs[0]?.url).toBe('https://a.example.com');
+    expect(tabs[0]?.sessionId).toBe('ses-a');
+    expect(tabs[1]?.url).toBe('https://b.example.com');
+    expect(tabs[1]?.sessionId).toBe('ses-b');
+    expect(tabs[2]?.url).toBe('https://c.example.com');
+    expect(tabs[2]?.sessionId).toBe('ses-c');
+  });
+
+  it('リトライ不要: 1回目でマッチした場合は2回目を呼ばない', async () => {
+    installChromeMock({
+      tabs: [
+        {
+          id: 1,
+          windowId: 10,
+          index: 0,
+          active: true,
+          pinned: false,
+          url: 'https://a.example.com',
+          title: 'A',
+        },
+      ],
+      groups: [],
+    });
+
+    let callCount = 0;
+    (chrome.sessions.getRecentlyClosed as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      callCount++;
+      return Promise.resolve([{ tab: { url: 'https://a.example.com', sessionId: 'session-a' } }]);
+    });
+
+    await runSaveAndCloseCurrentWindow();
+
+    // 1回目でマッチするのでリトライは発生しない
+    expect(callCount).toBe(1);
   });
 
   it('履歴セット数は上限を超えない', async () => {

--- a/src/background/commands.ts
+++ b/src/background/commands.ts
@@ -6,12 +6,14 @@ import {
   type GroupInput,
   type TabInput,
 } from '../tab-manager/history';
-import { getState, prependHistorySet } from '../tab-manager/storage';
+import { getState, prependHistorySet, updateState } from '../tab-manager/storage';
+import type { HistorySet } from '../tab-manager/types';
 import {
   ensureManagerTabInWindow,
   filterOutManagerTabs,
   openManagerTabInCurrentWindow,
 } from './managerTab';
+import { getRecentlyClosedSessions, matchSessionIds } from './sessions';
 
 const MAX_HISTORY_SETS = 200;
 
@@ -99,6 +101,34 @@ async function resolveWindowContext(clickedTab?: chrome.tabs.Tab): Promise<Windo
   };
 }
 
+function enrichHistorySetWithSessionIds(
+  set: HistorySet,
+  urlToSessionIds: Map<string, string[]>,
+): HistorySet {
+  if (urlToSessionIds.size === 0) {
+    return set;
+  }
+  // 各 URL の sessionId を貪欲に消費するためにコピーを作成
+  const remaining = new Map<string, string[]>();
+  for (const [url, ids] of urlToSessionIds) {
+    remaining.set(url, [...ids]);
+  }
+  return {
+    ...set,
+    tabs: set.tabs.map((tab) => {
+      const ids = remaining.get(tab.url);
+      if (!ids || ids.length === 0) {
+        return tab;
+      }
+      const sessionId = ids.shift();
+      if (sessionId === undefined) {
+        return tab;
+      }
+      return { ...tab, sessionId };
+    }),
+  };
+}
+
 async function saveTabsAndClose(
   windowId: number,
   sourceTabs: chrome.tabs.Tab[],
@@ -158,6 +188,43 @@ async function saveTabsAndClose(
   }
 
   await closeTabs(tabIds);
+
+  // sessionId 取得・付与（ベストエフォート）
+  try {
+    const closedTabUrls = savableTabs.map((tab) => getTabUrl(tab));
+    let sessions = await getRecentlyClosedSessions(closedTabUrls.length + 10);
+    let sessionIdMap = matchSessionIds(closedTabUrls, sessions);
+    // マッチ件数が0の場合は100ms待機して1回リトライ
+    if (sessionIdMap.size === 0 && closedTabUrls.length > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      sessions = await getRecentlyClosedSessions(closedTabUrls.length + 10);
+      sessionIdMap = matchSessionIds(closedTabUrls, sessions);
+    }
+    if (sessionIdMap.size > 0) {
+      // sessionIdMap (key: closedTabUrls index, value: sessionId) を
+      // URL → sessionId[] のマップに変換。buildHistorySet でタブが index ソートされるため、
+      // 配列インデックスではなく URL ベースで HistorySet のタブと照合する。
+      const urlToSessionIds = new Map<string, string[]>();
+      for (const [urlIdx, sessionId] of sessionIdMap) {
+        const url = closedTabUrls[urlIdx];
+        if (url === undefined) continue;
+        const list = urlToSessionIds.get(url) ?? [];
+        list.push(sessionId);
+        urlToSessionIds.set(url, list);
+      }
+      await updateState((current) => ({
+        ...current,
+        historySets: current.historySets.map((item) => {
+          if (item.id !== historySet.id) {
+            return item;
+          }
+          return enrichHistorySetWithSessionIds(item, urlToSessionIds);
+        }),
+      }));
+    }
+  } catch (err) {
+    console.warn('Failed to enrich history set with session IDs', err);
+  }
 }
 
 export async function runOpenManagerInCurrentWindow(clickedTab?: chrome.tabs.Tab) {

--- a/src/background/sessions.test.ts
+++ b/src/background/sessions.test.ts
@@ -1,0 +1,334 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getRecentlyClosedSessions, matchSessionIds } from './sessions';
+
+describe('getRecentlyClosedSessions', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('maxResults なしで chrome.sessions.getRecentlyClosed を呼ぶ', async () => {
+    const mockSessions: chrome.sessions.Session[] = [];
+    const getRecentlyClosed = vi.fn().mockResolvedValue(mockSessions);
+    vi.stubGlobal('chrome', {
+      sessions: { getRecentlyClosed },
+    });
+
+    const result = await getRecentlyClosedSessions();
+
+    expect(getRecentlyClosed).toHaveBeenCalledWith({});
+    expect(result).toBe(mockSessions);
+  });
+
+  it('maxResults ありで chrome.sessions.getRecentlyClosed を呼ぶ', async () => {
+    const mockSessions: chrome.sessions.Session[] = [];
+    const getRecentlyClosed = vi.fn().mockResolvedValue(mockSessions);
+    vi.stubGlobal('chrome', {
+      sessions: { getRecentlyClosed },
+    });
+
+    const result = await getRecentlyClosedSessions(10);
+
+    expect(getRecentlyClosed).toHaveBeenCalledWith({ maxResults: 10 });
+    expect(result).toBe(mockSessions);
+  });
+});
+
+describe('matchSessionIds', () => {
+  it('基本的な URL 一致マッチング', () => {
+    const sessions = [
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-1' } },
+      { tab: { url: 'https://b.example.com', sessionId: 'ses-2' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://a.example.com', 'https://b.example.com'], sessions);
+
+    expect(result.size).toBe(2);
+    expect(result.get(0)).toBe('ses-1');
+    expect(result.get(1)).toBe('ses-2');
+  });
+
+  it('session.tab のあるエントリのみマッチする（session.window は無視）', () => {
+    const sessions = [
+      {
+        window: {
+          id: 1,
+          tabs: [{ url: 'https://a.example.com' }],
+        },
+      },
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-tab' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://a.example.com'], sessions);
+
+    expect(result.size).toBe(1);
+    expect(result.get(0)).toBe('ses-tab');
+  });
+
+  it('同一 URL が複数ある場合の貪欲マッチ（配列の先頭から順にマッチ）', () => {
+    const sessions = [
+      { tab: { url: 'https://dup.example.com', sessionId: 'ses-newest' } },
+      { tab: { url: 'https://dup.example.com', sessionId: 'ses-older' } },
+      { tab: { url: 'https://dup.example.com', sessionId: 'ses-oldest' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(
+      ['https://dup.example.com', 'https://dup.example.com'],
+      sessions,
+    );
+
+    expect(result.size).toBe(2);
+    expect(result.get(0)).toBe('ses-newest');
+    expect(result.get(1)).toBe('ses-older');
+  });
+
+  it('マッチしない URL がある場合は Map に含まれない', () => {
+    const sessions = [
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-1' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(
+      ['https://a.example.com', 'https://no-match.example.com'],
+      sessions,
+    );
+
+    expect(result.size).toBe(1);
+    expect(result.get(0)).toBe('ses-1');
+    expect(result.has(1)).toBe(false);
+  });
+
+  it('sessionId がないセッションはスキップする', () => {
+    const sessions = [
+      { tab: { url: 'https://a.example.com', sessionId: undefined } },
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-valid' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://a.example.com'], sessions);
+
+    expect(result.size).toBe(1);
+    expect(result.get(0)).toBe('ses-valid');
+  });
+
+  it('空の入力に対して空の Map を返す', () => {
+    const result = matchSessionIds([], []);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('25件超のタブを閉じた場合、セッション数が足りない分はマッチしない', () => {
+    const urls = Array.from({ length: 30 }, (_, i) => `https://tab${i}.example.com`);
+    // Chrome は約25件までしかセッションを保持しない想定
+    const sessions = urls.slice(0, 25).map((url, i) => ({
+      tab: { url, sessionId: `ses-${i}` },
+    })) as chrome.sessions.Session[];
+
+    const result = matchSessionIds(urls, sessions);
+
+    expect(result.size).toBe(25);
+    for (let i = 0; i < 25; i++) {
+      expect(result.get(i)).toBe(`ses-${i}`);
+    }
+    for (let i = 25; i < 30; i++) {
+      expect(result.has(i)).toBe(false);
+    }
+  });
+
+  it('リダイレクト等でURLが変わったタブはマッチ不成立', () => {
+    const sessions = [
+      { tab: { url: 'https://redirected.example.com/final', sessionId: 'ses-redirect' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://original.example.com/start'], sessions);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('同一URL複数タブ保存時、セッション順序に基づく貪欲マッチで重複なく割り当てる', () => {
+    // ensureManagerTabInWindow でインデックスがシフトしても URL マッチには影響しない
+    const sessions = [
+      { tab: { url: 'https://same.example.com', sessionId: 'ses-3' } },
+      { tab: { url: 'https://same.example.com', sessionId: 'ses-2' } },
+      { tab: { url: 'https://same.example.com', sessionId: 'ses-1' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(
+      ['https://same.example.com', 'https://same.example.com', 'https://same.example.com'],
+      sessions,
+    );
+
+    expect(result.size).toBe(3);
+    // 各 URL に異なる sessionId が割り当てられる
+    const assignedIds = new Set([result.get(0), result.get(1), result.get(2)]);
+    expect(assignedIds.size).toBe(3);
+    // 貪欲マッチなので先頭から順に割り当て
+    expect(result.get(0)).toBe('ses-3');
+    expect(result.get(1)).toBe('ses-2');
+    expect(result.get(2)).toBe('ses-1');
+  });
+
+  it('session.tab.sessionId が null の場合はスキップする', () => {
+    const sessions = [
+      { tab: { url: 'https://a.example.com', sessionId: null } },
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-valid' } },
+    ] as unknown as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://a.example.com'], sessions);
+
+    expect(result.size).toBe(1);
+    expect(result.get(0)).toBe('ses-valid');
+  });
+
+  it('session.tab.url が undefined の場合はマッチしない', () => {
+    const sessions = [
+      { tab: { sessionId: 'ses-no-url' } },
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-with-url' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://a.example.com'], sessions);
+
+    expect(result.size).toBe(1);
+    expect(result.get(0)).toBe('ses-with-url');
+  });
+
+  it('session.tab.url が空文字の場合は空文字 URL とのみマッチする', () => {
+    const sessions = [
+      { tab: { url: '', sessionId: 'ses-empty-url' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://a.example.com', ''], sessions);
+
+    expect(result.size).toBe(1);
+    expect(result.has(0)).toBe(false);
+    expect(result.get(1)).toBe('ses-empty-url');
+  });
+
+  it('closedTabUrls に同じ URL が先に現れたものから貪欲消費される', () => {
+    // セッションが1つしかない場合、最初のURL にマッチして2番目は余る
+    const sessions = [
+      { tab: { url: 'https://dup.example.com', sessionId: 'ses-only-one' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(
+      ['https://dup.example.com', 'https://dup.example.com'],
+      sessions,
+    );
+
+    expect(result.size).toBe(1);
+    expect(result.get(0)).toBe('ses-only-one');
+    expect(result.has(1)).toBe(false);
+  });
+
+  it('session に tab と window の両プロパティがある場合は tab としてマッチする', () => {
+    // 現実の Chrome API では起きにくいが、型上は可能
+    const sessions = [
+      {
+        tab: { url: 'https://a.example.com', sessionId: 'ses-both' },
+        window: { id: 99 },
+      },
+    ] as unknown as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://a.example.com'], sessions);
+
+    expect(result.size).toBe(1);
+    expect(result.get(0)).toBe('ses-both');
+  });
+
+  it('tab セッションと window セッションが混在しても window の sessionId は選ばれない', () => {
+    const sessions = [
+      {
+        window: {
+          id: 1,
+          sessionId: 'ses-window',
+          tabs: [{ url: 'https://a.example.com' }, { url: 'https://b.example.com' }],
+        },
+      },
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-tab-a' } },
+      {
+        window: {
+          id: 2,
+          sessionId: 'ses-window-2',
+          tabs: [{ url: 'https://b.example.com' }],
+        },
+      },
+      { tab: { url: 'https://b.example.com', sessionId: 'ses-tab-b' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://a.example.com', 'https://b.example.com'], sessions);
+
+    expect(result.size).toBe(2);
+    expect(result.get(0)).toBe('ses-tab-a');
+    expect(result.get(1)).toBe('ses-tab-b');
+  });
+
+  it('session.tab.sessionId が空文字の場合はスキップする', () => {
+    const sessions = [
+      { tab: { url: 'https://a.example.com', sessionId: '' } },
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-valid' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://a.example.com'], sessions);
+
+    expect(result.size).toBe(1);
+    expect(result.get(0)).toBe('ses-valid');
+  });
+
+  it('closedTabUrls が sessions より多い場合、余った URL はマッチしない', () => {
+    const sessions = [
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-a' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(
+      ['https://a.example.com', 'https://b.example.com', 'https://c.example.com'],
+      sessions,
+    );
+
+    expect(result.size).toBe(1);
+    expect(result.get(0)).toBe('ses-a');
+  });
+
+  it('sessions が closedTabUrls より多い場合、余ったセッションは無視される', () => {
+    const sessions = [
+      { tab: { url: 'https://a.example.com', sessionId: 'ses-a' } },
+      { tab: { url: 'https://b.example.com', sessionId: 'ses-b' } },
+      { tab: { url: 'https://c.example.com', sessionId: 'ses-c' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://b.example.com'], sessions);
+
+    expect(result.size).toBe(1);
+    expect(result.get(0)).toBe('ses-b');
+  });
+
+  it('URL が大文字小文字で異なる場合はマッチしない（完全一致）', () => {
+    const sessions = [
+      { tab: { url: 'https://Example.COM/Page', sessionId: 'ses-upper' } },
+    ] as chrome.sessions.Session[];
+
+    const result = matchSessionIds(['https://example.com/page'], sessions);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('URL にクエリ文字列やフラグメントがある場合も完全一致のみ', () => {
+    const sessions = [
+      { tab: { url: 'https://example.com/page?key=value', sessionId: 'ses-query' } },
+    ] as chrome.sessions.Session[];
+
+    // クエリなし URL はマッチしない
+    const result1 = matchSessionIds(['https://example.com/page'], sessions);
+    expect(result1.size).toBe(0);
+
+    // 完全一致のみマッチ
+    const result2 = matchSessionIds(['https://example.com/page?key=value'], sessions);
+    expect(result2.size).toBe(1);
+    expect(result2.get(0)).toBe('ses-query');
+  });
+
+  it('session.tab が存在するが url フィールドがない場合でもクラッシュしない', () => {
+    const sessions = [{ tab: { sessionId: 'ses-no-url' } }] as chrome.sessions.Session[];
+
+    // undefined === 'https://...' は false なのでクラッシュせずスキップ
+    const result = matchSessionIds(['https://example.com'], sessions);
+    expect(result.size).toBe(0);
+  });
+});

--- a/src/background/sessions.ts
+++ b/src/background/sessions.ts
@@ -1,0 +1,51 @@
+/**
+ * chrome.sessions.getRecentlyClosed() の Promise ラッパー
+ */
+export async function getRecentlyClosedSessions(
+  maxResults?: number,
+): Promise<chrome.sessions.Session[]> {
+  return chrome.sessions.getRecentlyClosed(maxResults !== undefined ? { maxResults } : {});
+}
+
+/**
+ * 閉じたタブの URL 配列と RecentlyClosed セッションをマッチングし、
+ * Map<number, string> (key: closedTabUrls 配列のインデックス, value: sessionId) を返す。
+ *
+ * - session.tab を持つエントリのみ対象（window セッションは除外）
+ * - URL 完全一致でマッチング
+ * - 同一 URL のタブが複数ある場合は getRecentlyClosed() の返却順序（最新が先頭）に基づく貪欲マッチ
+ */
+export function matchSessionIds(
+  closedTabUrls: string[],
+  sessions: chrome.sessions.Session[],
+): Map<number, string> {
+  const result = new Map<number, string>();
+
+  // セッションから tab セッションのみ抽出（window セッションは除外）
+  // 各セッションは1回だけ使用（貪欲マッチ）
+  // セッションから tab セッションかつ有効な sessionId を持つものだけ抽出
+  type TabSessionEntry = { url: string | undefined; sessionId: string };
+  const availableSessions: TabSessionEntry[] = [];
+  for (const s of sessions) {
+    if (s.tab !== undefined && typeof s.tab.sessionId === 'string' && s.tab.sessionId.length > 0) {
+      availableSessions.push({ url: s.tab.url, sessionId: s.tab.sessionId });
+    }
+  }
+
+  const usedSessionIndices = new Set<number>();
+
+  for (let urlIdx = 0; urlIdx < closedTabUrls.length; urlIdx++) {
+    const url = closedTabUrls[urlIdx];
+    for (let sesIdx = 0; sesIdx < availableSessions.length; sesIdx++) {
+      if (usedSessionIndices.has(sesIdx)) continue;
+      const entry = availableSessions[sesIdx];
+      if (entry.url === url) {
+        result.set(urlIdx, entry.sessionId);
+        usedSessionIndices.add(sesIdx);
+        break;
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/manager/ManagerApp.tsx
+++ b/src/manager/ManagerApp.tsx
@@ -64,6 +64,7 @@ import {
 import { cleanupHistorySet } from './restoreCleanup';
 import { shouldSuppressRestoreLoading } from './restorePolicy';
 import { resolveRestoreTarget } from './restoreTarget';
+import { restoreSession, moveTabToWindow, ungroupTab } from './sessionRestore';
 import { removeSetsEmptiedSince } from './setCleanup';
 import { matchesExpectedUrl } from './urlMatch';
 import {
@@ -1638,13 +1639,57 @@ async function restoreTabs(
     enabled: restoreLoadingSuppressionEnabled,
     tabCount: sortedTabs.length,
   });
+
+  // Phase 0: sessionId ありのタブを sessions.restore() で復元
+  const sessionRestoredTabs: Array<{ snapshot: TabSnapshot; tab: chrome.tabs.Tab }> = [];
+  const fallbackTabs: TabSnapshot[] = [];
+  let sessionRestoredCount = 0;
+
+  for (const tab of sortedTabs) {
+    if (!tab.sessionId) {
+      fallbackTabs.push(tab);
+      continue;
+    }
+    try {
+      const session = await restoreSession(tab.sessionId);
+      if (!session.tab || session.tab.id === undefined) {
+        fallbackTabs.push(tab);
+        continue;
+      }
+      const restoredTab = session.tab;
+      sessionRestoredCount++;
+
+      try {
+        if (restoredTab.windowId !== windowId) {
+          await moveTabToWindow(restoredTab.id!, windowId, baseTabIndex + tab.index);
+        }
+      } catch (err) {
+        console.warn('Failed to move session-restored tab to target window', err);
+      }
+
+      try {
+        if (restoredTab.groupId !== undefined && restoredTab.groupId !== -1) {
+          await ungroupTab(restoredTab.id!);
+        }
+      } catch (err) {
+        console.warn('Failed to ungroup session-restored tab', err);
+      }
+
+      sessionRestoredTabs.push({ snapshot: tab, tab: restoredTab });
+    } catch (err) {
+      console.warn('Failed to restore session, falling back to createTab', err);
+      fallbackTabs.push(tab);
+    }
+  }
+
+  // Phase 1: sessionId なし + Phase 0 フォールバック分を createTab で並列作成
   const creationResults = await Promise.allSettled(
-    sortedTabs.map((tab) => createTab(windowId, tab.url, baseTabIndex + tab.index)),
+    fallbackTabs.map((tab) => createTab(windowId, tab.url, baseTabIndex + tab.index)),
   );
   const createdTabs: Array<{ snapshot: TabSnapshot; tab: chrome.tabs.Tab }> = [];
   const failedTabs: TabSnapshot[] = [];
   creationResults.forEach((result, index) => {
-    const snapshot = sortedTabs[index];
+    const snapshot = fallbackTabs[index];
     if (!snapshot) {
       return;
     }
@@ -1656,8 +1701,12 @@ async function restoreTabs(
     failedTabs.push(snapshot);
   });
 
+  // 全復元タブ = Phase 0 + Phase 1
+  const allRestoredTabs = [...sessionRestoredTabs, ...createdTabs];
+
+  // Phase 2: グループ復元
   const groupTabIds = new Map<number, number[]>();
-  for (const { snapshot, tab } of createdTabs) {
+  for (const { snapshot, tab } of allRestoredTabs) {
     if (snapshot.groupId === null || tab.id === undefined) {
       continue;
     }
@@ -1691,9 +1740,10 @@ async function restoreTabs(
     }
   }
 
+  // Phase 3: shouldDiscard 時のメモリ最適化
   if (shouldDiscard) {
-    const restoredTabs = await Promise.all(
-      createdTabs.map(async ({ snapshot, tab }) => {
+    const restoredSnapshots = await Promise.all(
+      allRestoredTabs.map(async ({ snapshot, tab }) => {
         if (tab.id === undefined) {
           return snapshot;
         }
@@ -1709,10 +1759,14 @@ async function restoreTabs(
         return snapshot;
       }),
     );
-    return { restoredTabs, failedTabs };
+    return { restoredTabs: restoredSnapshots, failedTabs, sessionRestoredCount };
   }
 
-  return { restoredTabs: createdTabs.map((item) => item.snapshot), failedTabs };
+  return {
+    restoredTabs: allRestoredTabs.map((item) => item.snapshot),
+    failedTabs,
+    sessionRestoredCount,
+  };
 }
 
 export function ManagerApp() {
@@ -2415,7 +2469,7 @@ export function ManagerApp() {
       const restoreWindow = restoreTarget === 'new-window' ? await createRestoreWindow() : null;
       const windowId = restoreWindow?.windowId ?? currentManager.windowId;
       const baseTabIndex = await getWindowTabCount(windowId);
-      const { restoredTabs, failedTabs } = await restoreTabs(
+      const { restoredTabs, failedTabs, sessionRestoredCount } = await restoreTabs(
         targetSet.tabs,
         targetSet.groups,
         windowId,
@@ -2445,10 +2499,17 @@ export function ManagerApp() {
         }));
         await refreshState(updated.historySets);
       }
+      const total = targetSet.tabs.length;
       if (failedTabs.length > 0) {
         setActionMessage(
-          `${targetSet.tabs.length} 件中 ${restoredTabs.length} 件のタブを復元しました。`,
+          sessionRestoredCount > 0
+            ? `${total}件中${restoredTabs.length}件のタブを復元しました（${sessionRestoredCount}件が履歴付き）。`
+            : `${total}件中${restoredTabs.length}件のタブを復元しました。`,
         );
+      } else if (sessionRestoredCount > 0 && sessionRestoredCount === total) {
+        setActionMessage(`タブを復元しました（全${total}件が履歴付き）。`);
+      } else if (sessionRestoredCount > 0) {
+        setActionMessage(`${total}件中${sessionRestoredCount}件が履歴付きで復元されました。`);
       } else {
         setActionMessage('タブを復元しました。');
       }
@@ -2475,7 +2536,7 @@ export function ManagerApp() {
         setActionMessage('復元できるタブがありません。');
         return;
       }
-      const { restoredTabs, failedTabs } = await restoreTabs(
+      const { restoredTabs, failedTabs, sessionRestoredCount } = await restoreTabs(
         tabs,
         [group],
         windowId,
@@ -2496,7 +2557,15 @@ export function ManagerApp() {
         await refreshState(updated.historySets);
       }
       if (failedTabs.length > 0) {
-        setActionMessage(`${tabs.length} 件中 ${restoredTabs.length} 件のタブを復元しました。`);
+        setActionMessage(
+          sessionRestoredCount > 0
+            ? `${tabs.length}件中${restoredTabs.length}件のタブを復元しました（${sessionRestoredCount}件が履歴付き）。`
+            : `${tabs.length}件中${restoredTabs.length}件のタブを復元しました。`,
+        );
+      } else if (sessionRestoredCount > 0 && sessionRestoredCount === tabs.length) {
+        setActionMessage(`グループを復元しました（全${tabs.length}件が履歴付き）。`);
+      } else if (sessionRestoredCount > 0) {
+        setActionMessage(`${tabs.length}件中${sessionRestoredCount}件が履歴付きで復元されました。`);
       } else {
         setActionMessage('グループを復元しました。');
       }
@@ -2511,7 +2580,7 @@ export function ManagerApp() {
     try {
       const windowId = await getCurrentWindowId();
       const baseTabIndex = await getWindowTabCount(windowId);
-      const { restoredTabs } = await restoreTabs(
+      const { restoredTabs, sessionRestoredCount } = await restoreTabs(
         [tab],
         [],
         windowId,
@@ -2532,7 +2601,9 @@ export function ManagerApp() {
         await refreshState(updated.historySets);
       }
       if (restoredTabs.length === 1) {
-        setActionMessage('タブを復元しました。');
+        setActionMessage(
+          sessionRestoredCount > 0 ? 'タブを復元しました（履歴付き）。' : 'タブを復元しました。',
+        );
       } else {
         setActionMessage('タブの復元に失敗しました。');
       }

--- a/src/manager/sessionRestore.test.ts
+++ b/src/manager/sessionRestore.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { moveTabToWindow, restoreSession, ungroupTab } from './sessionRestore';
+
+describe('restoreSession', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('chrome.sessions.restore を正しく呼び出す', async () => {
+    const mockSession = {
+      tab: { id: 1, url: 'https://example.com' },
+    } as chrome.sessions.Session;
+    const restore = vi.fn().mockResolvedValue(mockSession);
+    vi.stubGlobal('chrome', {
+      sessions: { restore },
+    });
+
+    const result = await restoreSession('ses-123');
+
+    expect(restore).toHaveBeenCalledWith('ses-123');
+    expect(result).toBe(mockSession);
+  });
+});
+
+describe('moveTabToWindow', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('chrome.tabs.move を正しいパラメータで呼び出す', async () => {
+    const mockTab = { id: 5, windowId: 10, index: 2 } as chrome.tabs.Tab;
+    const move = vi.fn().mockResolvedValue(mockTab);
+    vi.stubGlobal('chrome', {
+      tabs: { move },
+    });
+
+    const result = await moveTabToWindow(5, 10, 2);
+
+    expect(move).toHaveBeenCalledWith(5, { windowId: 10, index: 2 });
+    expect(result).toBe(mockTab);
+  });
+
+  it('配列結果の場合も最初の要素を返す', async () => {
+    const mockTab = { id: 5, windowId: 10, index: 2 } as chrome.tabs.Tab;
+    const move = vi.fn().mockResolvedValue([mockTab]);
+    vi.stubGlobal('chrome', {
+      tabs: { move },
+    });
+
+    const result = await moveTabToWindow(5, 10, 2);
+
+    expect(result).toBe(mockTab);
+  });
+});
+
+describe('ungroupTab', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('chrome.tabs.ungroup を正しく呼び出す', async () => {
+    const ungroup = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('chrome', {
+      tabs: { ungroup },
+    });
+
+    await ungroupTab(42);
+
+    expect(ungroup).toHaveBeenCalledWith([42]);
+  });
+
+  it('chrome.tabs.ungroup が失敗した場合は例外が伝播する', async () => {
+    const ungroup = vi.fn().mockRejectedValue(new Error('ungroup failed'));
+    vi.stubGlobal('chrome', {
+      tabs: { ungroup },
+    });
+
+    await expect(ungroupTab(42)).rejects.toThrow('ungroup failed');
+  });
+});
+
+describe('restoreSession edge cases', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('chrome.sessions.restore が失敗した場合は例外が伝播する', async () => {
+    const restore = vi.fn().mockRejectedValue(new Error('session expired'));
+    vi.stubGlobal('chrome', {
+      sessions: { restore },
+    });
+
+    await expect(restoreSession('invalid-session')).rejects.toThrow('session expired');
+  });
+
+  it('chrome.sessions.restore が window セッションを返しても呼び出し元に渡る', async () => {
+    // restoreSession はラッパーなので戻り値をそのまま返す
+    // 呼び出し元の restoreTabs Phase 0 が session.tab チェックで弾く責務
+    const windowSession = {
+      window: { id: 10, tabs: [] },
+    } as unknown as chrome.sessions.Session;
+    const restore = vi.fn().mockResolvedValue(windowSession);
+    vi.stubGlobal('chrome', {
+      sessions: { restore },
+    });
+
+    const result = await restoreSession('ses-window');
+    expect(result).toBe(windowSession);
+    expect(result.tab).toBeUndefined();
+  });
+});
+
+describe('moveTabToWindow edge cases', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('chrome.tabs.move が失敗した場合は例外が伝播する', async () => {
+    const move = vi.fn().mockRejectedValue(new Error('tab not found'));
+    vi.stubGlobal('chrome', {
+      tabs: { move },
+    });
+
+    await expect(moveTabToWindow(999, 10, 0)).rejects.toThrow('tab not found');
+  });
+
+  it('chrome.tabs.move が空配列を返した場合は undefined を返す', async () => {
+    // Chrome API が空配列を返すケース（通常は起きないが型上は可能）
+    const move = vi.fn().mockResolvedValue([]);
+    vi.stubGlobal('chrome', {
+      tabs: { move },
+    });
+
+    const result = await moveTabToWindow(5, 10, 0);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/manager/sessionRestore.ts
+++ b/src/manager/sessionRestore.ts
@@ -1,0 +1,27 @@
+/**
+ * chrome.sessions.restore() の Promise ラッパー
+ * 復元された Session を返す
+ */
+export async function restoreSession(sessionId: string): Promise<chrome.sessions.Session> {
+  return chrome.sessions.restore(sessionId);
+}
+
+/**
+ * chrome.tabs.move() の Promise ラッパー
+ */
+export async function moveTabToWindow(
+  tabId: number,
+  windowId: number,
+  index: number,
+): Promise<chrome.tabs.Tab> {
+  const result = await chrome.tabs.move(tabId, { windowId, index });
+  return Array.isArray(result) ? result[0] : result;
+}
+
+/**
+ * chrome.tabs.ungroup() の Promise ラッパー
+ * sessions.restore() で復元されたタブが既存グループに属している場合に使用
+ */
+export async function ungroupTab(tabId: number): Promise<void> {
+  await chrome.tabs.ungroup([tabId]);
+}

--- a/src/tab-manager/history.test.ts
+++ b/src/tab-manager/history.test.ts
@@ -49,6 +49,92 @@ describe('buildHistorySet', () => {
     expect(result.tabs[0]?.favIconUrl).toBeUndefined();
   });
 
+  it('sessionId 付きタブから正しい TabSnapshot が生成される', () => {
+    const result = buildHistorySet({
+      id: 'set-session',
+      name: 'window-session',
+      createdAt: 1700000000000,
+      windowId: 5,
+      managerBinding: null,
+      tabs: [
+        {
+          title: 'A',
+          url: 'https://a.com',
+          index: 0,
+          sessionId: 'session-abc-123',
+        },
+      ],
+      groups: [],
+    });
+
+    expect(result.tabs[0]?.sessionId).toBe('session-abc-123');
+  });
+
+  it('sessionId なしの場合は TabSnapshot に sessionId が含まれない', () => {
+    const result = buildHistorySet({
+      id: 'set-no-session',
+      name: 'window-no-session',
+      createdAt: 1700000000000,
+      windowId: 5,
+      managerBinding: null,
+      tabs: [
+        {
+          title: 'B',
+          url: 'https://b.com',
+          index: 0,
+        },
+      ],
+      groups: [],
+    });
+
+    expect(result.tabs[0]?.sessionId).toBeUndefined();
+    expect('sessionId' in result.tabs[0]!).toBe(false);
+  });
+
+  it('sessionId が空文字の場合は TabSnapshot に含まれない', () => {
+    const result = buildHistorySet({
+      id: 'set-empty-sid',
+      name: 'test',
+      createdAt: 1700000000000,
+      windowId: 5,
+      managerBinding: null,
+      tabs: [
+        {
+          title: 'Tab',
+          url: 'https://example.com',
+          index: 0,
+          sessionId: '',
+        },
+      ],
+      groups: [],
+    });
+
+    // normalizeTab は falsy チェック (tab.sessionId ?) で空文字を除外する
+    expect(result.tabs[0]?.sessionId).toBeUndefined();
+    expect('sessionId' in result.tabs[0]!).toBe(false);
+  });
+
+  it('sessionId 付きタブと sessionId なしタブが混在する場合', () => {
+    const result = buildHistorySet({
+      id: 'set-mixed',
+      name: 'mixed',
+      createdAt: 1700000000000,
+      windowId: 5,
+      managerBinding: null,
+      tabs: [
+        { title: 'With', url: 'https://with.com', index: 0, sessionId: 'ses-1' },
+        { title: 'Without', url: 'https://without.com', index: 1 },
+        { title: 'Also With', url: 'https://also.com', index: 2, sessionId: 'ses-2' },
+      ],
+      groups: [],
+    });
+
+    expect(result.tabs[0]?.sessionId).toBe('ses-1');
+    expect(result.tabs[1]?.sessionId).toBeUndefined();
+    expect('sessionId' in result.tabs[1]!).toBe(false);
+    expect(result.tabs[2]?.sessionId).toBe('ses-2');
+  });
+
   it('名前が空文字の場合は既定名へフォールバックする', () => {
     const result = buildHistorySet({
       id: 'set-2',

--- a/src/tab-manager/history.ts
+++ b/src/tab-manager/history.ts
@@ -11,6 +11,7 @@ export type TabInput = {
   index: number;
   groupId?: number;
   locked?: boolean;
+  sessionId?: string;
 };
 
 export type GroupInput = {
@@ -55,6 +56,7 @@ function normalizeTab(tab: TabInput): TabSnapshot {
     index: tab.index,
     groupId,
     locked: tab.locked ?? false,
+    ...(tab.sessionId ? { sessionId: tab.sessionId } : {}),
   };
 }
 

--- a/src/tab-manager/storage.test.ts
+++ b/src/tab-manager/storage.test.ts
@@ -496,6 +496,163 @@ describe('storage', () => {
     expect(state.cardHeight).toBeNull();
   });
 
+  it('タブの sessionId は文字列のみ保持する', async () => {
+    const storage = createMemoryStorage({
+      tabManagerState: {
+        version: 1,
+        exclusions: [],
+        historySets: [
+          {
+            id: 'set-session',
+            createdAt: 3,
+            windowId: 4,
+            name: 'window-session',
+            locked: false,
+            managerBinding: null,
+            groups: [],
+            tabs: [
+              {
+                uid: 't-1',
+                title: 'Docs',
+                url: 'https://docs.example.com',
+                index: 0,
+                groupId: null,
+                locked: false,
+                sessionId: 'session-abc-123',
+              },
+              {
+                uid: 't-2',
+                title: 'Mail',
+                url: 'https://mail.example.com',
+                index: 1,
+                groupId: null,
+                locked: false,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const state = await getState(storage);
+    const tabs = state.historySets[0]?.tabs ?? [];
+
+    expect(tabs[0]?.sessionId).toBe('session-abc-123');
+    expect(tabs[1]?.sessionId).toBeUndefined();
+  });
+
+  it('sessionId が空文字の場合は除外される', async () => {
+    const storage = createMemoryStorage({
+      tabManagerState: {
+        version: 1,
+        exclusions: [],
+        historySets: [
+          {
+            id: 'set-empty-sid',
+            createdAt: 1,
+            windowId: 1,
+            name: 'test',
+            locked: false,
+            managerBinding: null,
+            groups: [],
+            tabs: [
+              {
+                uid: 't-1',
+                title: 'Tab',
+                url: 'https://example.com',
+                index: 0,
+                groupId: null,
+                locked: false,
+                sessionId: '',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const state = await getState(storage);
+    expect(state.historySets[0]?.tabs[0]?.sessionId).toBeUndefined();
+  });
+
+  it('sessionId が null の場合は除外される', async () => {
+    const storage = createMemoryStorage({
+      tabManagerState: {
+        version: 1,
+        exclusions: [],
+        historySets: [
+          {
+            id: 'set-null-sid',
+            createdAt: 1,
+            windowId: 1,
+            name: 'test',
+            locked: false,
+            managerBinding: null,
+            groups: [],
+            tabs: [
+              {
+                uid: 't-1',
+                title: 'Tab',
+                url: 'https://example.com',
+                index: 0,
+                groupId: null,
+                locked: false,
+                sessionId: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const state = await getState(storage);
+    expect(state.historySets[0]?.tabs[0]?.sessionId).toBeUndefined();
+  });
+
+  it('sessionId が数値や真偽値の場合は除外される', async () => {
+    const storage = createMemoryStorage({
+      tabManagerState: {
+        version: 1,
+        exclusions: [],
+        historySets: [
+          {
+            id: 'set-bad-sid',
+            createdAt: 1,
+            windowId: 1,
+            name: 'test',
+            locked: false,
+            managerBinding: null,
+            groups: [],
+            tabs: [
+              {
+                uid: 't-num',
+                title: 'Num',
+                url: 'https://num.example.com',
+                index: 0,
+                groupId: null,
+                locked: false,
+                sessionId: 12345,
+              },
+              {
+                uid: 't-bool',
+                title: 'Bool',
+                url: 'https://bool.example.com',
+                index: 1,
+                groupId: null,
+                locked: false,
+                sessionId: true,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const state = await getState(storage);
+    expect(state.historySets[0]?.tabs[0]?.sessionId).toBeUndefined();
+    expect(state.historySets[0]?.tabs[1]?.sessionId).toBeUndefined();
+  });
+
   it('cardHeight は小数を整数に丸める', async () => {
     const storage = createMemoryStorage({
       tabManagerState: {

--- a/src/tab-manager/storage.ts
+++ b/src/tab-manager/storage.ts
@@ -156,6 +156,9 @@ function normalizeHistorySets(rawSets: unknown): HistorySet[] {
           index: typeof tab.index === 'number' ? tab.index : 0,
           groupId: typeof tab.groupId === 'number' ? tab.groupId : null,
           locked: normalizeLocked(tab.locked),
+          ...(typeof tab.sessionId === 'string' && tab.sessionId.length > 0
+            ? { sessionId: tab.sessionId }
+            : {}),
         };
       });
       const normalizedSet: HistorySet = {

--- a/src/tab-manager/types.ts
+++ b/src/tab-manager/types.ts
@@ -17,6 +17,7 @@ export type TabSnapshot = {
   index: number;
   groupId: number | null;
   locked: boolean;
+  sessionId?: string;
 };
 
 export type ManagerBinding = {


### PR DESCRIPTION
## Summary
- タブ保存時に`chrome.sessions.getRecentlyClosed()`でsessionIdを取得し、HistorySetに付与
- タブ復元時に`chrome.sessions.restore(sessionId)`で履歴付きタブを復元（フォールバック: `chrome.tabs.create()`）
- 復元結果の通知メッセージに履歴付き件数を表示

## 変更内容
- `TabSnapshot`型に`sessionId?: string`を追加（後方互換）
- `manifest.json`に`sessions`パーミッションを追加
- `src/background/sessions.ts`: セッション取得・URLマッチングユーティリティ
- `src/manager/sessionRestore.ts`: `sessions.restore()`/`tabs.move()`/`tabs.ungroup()`のラッパー
- `src/background/commands.ts`: 保存フローにsessionId取得・付与を統合
- `src/manager/ManagerApp.tsx`: 復元フローに4フェーズ構造を導入（Phase 0: session復元 → Phase 1: createTabフォールバック → Phase 2: グループ再構成 → Phase 3: メモリ最適化）

## Test plan
- [x] `pnpm test`: 219テスト全パス
- [x] `pnpm check`: lint + format + typecheck パス
- [x] `pnpm build`: 本番ビルド成功
- [x] 手動テスト: 5タブ保存→復元→戻るボタンが活性化（履歴保持を確認）

Closes #14