### PR TITLE
fix: タブグループ復元時に名前が空になるバグを修正

### DIFF
--- a/src/manager/ManagerApp.tsx
+++ b/src/manager/ManagerApp.tsx
@@ -67,6 +67,7 @@ import { resolveRestoreTarget } from './restoreTarget';
 import { restoreSession, moveTabToWindow, ungroupTab } from './sessionRestore';
 import { removeSetsEmptiedSince } from './setCleanup';
 import { matchesExpectedUrl } from './urlMatch';
+import { restoreGroupWithRetry } from './groupRestore';
 import {
   getBindingStatusLabel,
   resolveBindingStatus,
@@ -1591,42 +1592,6 @@ async function waitForTabUrl(tabId: number, expectedUrl: string, timeoutMs = 300
   });
 }
 
-async function groupTabs(windowId: number, tabIds: number[]) {
-  return new Promise<number>((resolve, reject) => {
-    chrome.tabs.group({ createProperties: { windowId }, tabIds }, (groupId: number) => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-        return;
-      }
-      resolve(groupId);
-    });
-  });
-}
-
-async function updateTabGroup(groupId: number, group: GroupSnapshot) {
-  return new Promise<void>((resolve, reject) => {
-    chrome.tabGroups.update(groupId, { title: group.title, color: group.color }, () => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-        return;
-      }
-      resolve();
-    });
-  });
-}
-
-async function moveTabGroup(groupId: number, index: number) {
-  return new Promise<void>((resolve, reject) => {
-    chrome.tabGroups.move(groupId, { index }, () => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-        return;
-      }
-      resolve();
-    });
-  });
-}
-
 async function restoreTabs(
   tabs: TabSnapshot[],
   groups: GroupSnapshot[],
@@ -1721,22 +1686,15 @@ async function restoreTabs(
     if (!tabIds || tabIds.length === 0) {
       continue;
     }
-    let newGroupId: number | null = null;
-    try {
-      newGroupId = await groupTabs(windowId, tabIds);
-    } catch (err) {
-      console.error('Failed to create tab group', err);
+    const newGroupId = await restoreGroupWithRetry(
+      windowId,
+      tabIds,
+      group.title,
+      group.color,
+      baseTabIndex + group.index,
+    );
+    if (newGroupId === null) {
       continue;
-    }
-    try {
-      await updateTabGroup(newGroupId, group);
-    } catch (err) {
-      console.error('Failed to update tab group', err);
-    }
-    try {
-      await moveTabGroup(newGroupId, baseTabIndex + group.index);
-    } catch (err) {
-      console.error('Failed to move tab group', err);
     }
   }
 

--- a/src/manager/groupRestore.test.ts
+++ b/src/manager/groupRestore.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { restoreGroupWithRetry } from './groupRestore';
+
+type ChromeRuntimeState = {
+  lastError: Error | null;
+};
+
+function stubChrome() {
+  const runtime: ChromeRuntimeState = {
+    lastError: null,
+  };
+
+  const tabsGroup = vi.fn();
+  const tabGroupsUpdate = vi.fn();
+  const tabGroupsGet = vi.fn();
+  const tabGroupsMove = vi.fn();
+
+  vi.stubGlobal('chrome', {
+    runtime,
+    tabs: {
+      group: tabsGroup,
+    },
+    tabGroups: {
+      update: tabGroupsUpdate,
+      get: tabGroupsGet,
+      move: tabGroupsMove,
+    },
+  });
+
+  return {
+    runtime,
+    tabsGroup,
+    tabGroupsGet,
+    tabGroupsMove,
+    tabGroupsUpdate,
+  };
+}
+
+describe('restoreGroupWithRetry', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('初回の検証で title と color が一致した場合は groupId を返す', async () => {
+    const { tabsGroup, tabGroupsGet, tabGroupsMove, tabGroupsUpdate } = stubChrome();
+    tabsGroup.mockImplementation((_options: unknown, callback: (groupId: number) => void) => {
+      callback(91);
+    });
+    tabGroupsUpdate.mockImplementation(
+      (_groupId: number, _options: unknown, callback: () => void) => {
+        callback();
+      },
+    );
+    tabGroupsGet.mockImplementation(
+      (_groupId: number, callback: (group: chrome.tabGroups.TabGroup) => void) => {
+        callback({ id: 91, title: 'Work', color: 'blue' } as chrome.tabGroups.TabGroup);
+      },
+    );
+    tabGroupsMove.mockImplementation(
+      (_groupId: number, _options: unknown, callback: () => void) => {
+        callback();
+      },
+    );
+
+    const result = await restoreGroupWithRetry(5, [10, 11], 'Work', 'blue', 3);
+
+    expect(result).toBe(91);
+    expect(tabsGroup).toHaveBeenCalledTimes(1);
+    expect(tabsGroup).toHaveBeenCalledWith(
+      { createProperties: { windowId: 5 }, tabIds: [10, 11] },
+      expect.any(Function),
+    );
+    expect(tabGroupsUpdate).toHaveBeenCalledTimes(1);
+    expect(tabGroupsUpdate).toHaveBeenCalledWith(
+      91,
+      { title: 'Work', color: 'blue' },
+      expect.any(Function),
+    );
+    expect(tabGroupsGet).toHaveBeenCalledTimes(1);
+    expect(tabGroupsGet).toHaveBeenCalledWith(91, expect.any(Function));
+    expect(tabGroupsMove).toHaveBeenCalledWith(91, { index: 3 }, expect.any(Function));
+  });
+
+  it('検証で title が空のままなら待機して再試行し、次回成功したら返す', async () => {
+    const { tabsGroup, tabGroupsGet, tabGroupsMove, tabGroupsUpdate } = stubChrome();
+    tabsGroup.mockImplementation((_options: unknown, callback: (groupId: number) => void) => {
+      callback(91);
+    });
+    tabGroupsUpdate.mockImplementation(
+      (_groupId: number, _options: unknown, callback: () => void) => {
+        callback();
+      },
+    );
+    tabGroupsGet
+      .mockImplementationOnce(
+        (_groupId: number, callback: (group: chrome.tabGroups.TabGroup) => void) => {
+          callback({ id: 91, title: '', color: 'blue' } as chrome.tabGroups.TabGroup);
+        },
+      )
+      .mockImplementationOnce(
+        (_groupId: number, callback: (group: chrome.tabGroups.TabGroup) => void) => {
+          callback({ id: 91, title: 'Work', color: 'blue' } as chrome.tabGroups.TabGroup);
+        },
+      );
+    tabGroupsMove.mockImplementation(
+      (_groupId: number, _options: unknown, callback: () => void) => {
+        callback();
+      },
+    );
+
+    const promise = restoreGroupWithRetry(5, [10, 11], 'Work', 'blue', 3);
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(result).toBe(91);
+    expect(tabGroupsUpdate).toHaveBeenCalledTimes(2);
+    expect(tabGroupsGet).toHaveBeenCalledTimes(2);
+    expect(tabGroupsMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('検証で color が一致しない場合も再試行する', async () => {
+    const { tabsGroup, tabGroupsGet, tabGroupsMove, tabGroupsUpdate } = stubChrome();
+    tabsGroup.mockImplementation((_options: unknown, callback: (groupId: number) => void) => {
+      callback(91);
+    });
+    tabGroupsUpdate.mockImplementation(
+      (_groupId: number, _options: unknown, callback: () => void) => {
+        callback();
+      },
+    );
+    tabGroupsGet
+      .mockImplementationOnce(
+        (_groupId: number, callback: (group: chrome.tabGroups.TabGroup) => void) => {
+          callback({ id: 91, title: 'Work', color: 'grey' } as chrome.tabGroups.TabGroup);
+        },
+      )
+      .mockImplementationOnce(
+        (_groupId: number, callback: (group: chrome.tabGroups.TabGroup) => void) => {
+          callback({ id: 91, title: 'Work', color: 'blue' } as chrome.tabGroups.TabGroup);
+        },
+      );
+    tabGroupsMove.mockImplementation(
+      (_groupId: number, _options: unknown, callback: () => void) => {
+        callback();
+      },
+    );
+
+    const promise = restoreGroupWithRetry(5, [10, 11], 'Work', 'blue', 3);
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(result).toBe(91);
+    expect(tabGroupsUpdate).toHaveBeenCalledTimes(2);
+    expect(tabGroupsGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('groupTabs が失敗した場合は null を返す', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runtime, tabsGroup, tabGroupsGet, tabGroupsMove, tabGroupsUpdate } = stubChrome();
+    tabsGroup.mockImplementation((_options: unknown, callback: (groupId: number) => void) => {
+      runtime.lastError = new Error('group failed');
+      callback(-1);
+    });
+
+    const result = await restoreGroupWithRetry(5, [10, 11], 'Work', 'blue', 3);
+
+    expect(result).toBeNull();
+    expect(tabGroupsUpdate).not.toHaveBeenCalled();
+    expect(tabGroupsGet).not.toHaveBeenCalled();
+    expect(tabGroupsMove).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith('Failed to create tab group', expect.any(Error));
+  });
+
+  it('検証が3回とも失敗した場合は警告して groupId を返す', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { tabsGroup, tabGroupsGet, tabGroupsMove, tabGroupsUpdate } = stubChrome();
+    tabsGroup.mockImplementation((_options: unknown, callback: (groupId: number) => void) => {
+      callback(91);
+    });
+    tabGroupsUpdate.mockImplementation(
+      (_groupId: number, _options: unknown, callback: () => void) => {
+        callback();
+      },
+    );
+    tabGroupsGet.mockImplementation(
+      (_groupId: number, callback: (group: chrome.tabGroups.TabGroup) => void) => {
+        callback({ id: 91, title: '', color: 'blue' } as chrome.tabGroups.TabGroup);
+      },
+    );
+    tabGroupsMove.mockImplementation(
+      (_groupId: number, _options: unknown, callback: () => void) => {
+        callback();
+      },
+    );
+
+    const promise = restoreGroupWithRetry(5, [10, 11], 'Work', 'blue', 3);
+    await vi.advanceTimersByTimeAsync(200);
+    const result = await promise;
+
+    expect(result).toBe(91);
+    expect(tabGroupsUpdate).toHaveBeenCalledTimes(3);
+    expect(tabGroupsGet).toHaveBeenCalledTimes(3);
+    expect(tabGroupsMove).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('moveTabGroup が失敗した場合は警告だけ出して groupId を返す', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { runtime, tabsGroup, tabGroupsGet, tabGroupsMove, tabGroupsUpdate } = stubChrome();
+    tabsGroup.mockImplementation((_options: unknown, callback: (groupId: number) => void) => {
+      callback(91);
+    });
+    tabGroupsUpdate.mockImplementation(
+      (_groupId: number, _options: unknown, callback: () => void) => {
+        callback();
+      },
+    );
+    tabGroupsGet.mockImplementation(
+      (_groupId: number, callback: (group: chrome.tabGroups.TabGroup) => void) => {
+        callback({ id: 91, title: 'Work', color: 'blue' } as chrome.tabGroups.TabGroup);
+      },
+    );
+    tabGroupsMove.mockImplementation(
+      (_groupId: number, _options: unknown, callback: () => void) => {
+        runtime.lastError = new Error('move failed');
+        callback();
+      },
+    );
+
+    const result = await restoreGroupWithRetry(5, [10, 11], 'Work', 'blue', 3);
+
+    expect(result).toBe(91);
+    expect(warnSpy).toHaveBeenCalledWith('Failed to move tab group', expect.any(Error));
+  });
+});

--- a/src/manager/groupRestore.ts
+++ b/src/manager/groupRestore.ts
@@ -1,0 +1,124 @@
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 100;
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isGroupApplied(
+  group: chrome.tabGroups.TabGroup,
+  expectedTitle: string,
+  expectedColor: chrome.tabGroups.ColorEnum,
+) {
+  return group.title === expectedTitle && group.color === expectedColor;
+}
+
+async function groupTabs(windowId: number, tabIds: number[]) {
+  return new Promise<number>((resolve, reject) => {
+    chrome.tabs.group({ createProperties: { windowId }, tabIds }, (groupId: number) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve(groupId);
+    });
+  });
+}
+
+async function updateTabGroup(groupId: number, title: string, color: chrome.tabGroups.ColorEnum) {
+  return new Promise<void>((resolve, reject) => {
+    chrome.tabGroups.update(groupId, { title, color }, () => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function getTabGroup(groupId: number) {
+  return new Promise<chrome.tabGroups.TabGroup>((resolve, reject) => {
+    chrome.tabGroups.get(groupId, (group) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve(group);
+    });
+  });
+}
+
+async function moveTabGroup(groupId: number, index: number) {
+  return new Promise<void>((resolve, reject) => {
+    chrome.tabGroups.move(groupId, { index }, () => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function restoreGroupWithRetry(
+  windowId: number,
+  tabIds: number[],
+  title: string,
+  color: chrome.tabGroups.ColorEnum,
+  index: number,
+) {
+  let groupId: number;
+  try {
+    groupId = await groupTabs(windowId, tabIds);
+  } catch (err) {
+    console.error('Failed to create tab group', err);
+    return null;
+  }
+
+  let applied = false;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
+    try {
+      await updateTabGroup(groupId, title, color);
+      const updatedGroup = await getTabGroup(groupId);
+      if (isGroupApplied(updatedGroup, title, color)) {
+        applied = true;
+        break;
+      }
+    } catch (err) {
+      if (attempt === MAX_RETRIES) {
+        console.warn('Failed to update tab group after retries', err);
+        break;
+      }
+    }
+
+    if (attempt < MAX_RETRIES) {
+      await delay(RETRY_DELAY_MS);
+      continue;
+    }
+
+    console.warn('Tab group restore verification did not match expected state', {
+      groupId,
+      expectedTitle: title,
+      expectedColor: color,
+    });
+  }
+
+  if (!applied) {
+    console.warn('Continuing after tab group restore retries were exhausted', {
+      groupId,
+      title,
+      color,
+    });
+  }
+
+  try {
+    await moveTabGroup(groupId, index);
+  } catch (err) {
+    console.warn('Failed to move tab group', err);
+  }
+
+  return groupId;
+}


### PR DESCRIPTION
## Summary

- タブグループ復元時に `chrome.tabGroups.update()` が完了する前に処理が進み、グループ名が空になるバグを修正
- グループ作成→プロパティ更新→検証→移動の一連の処理を `restoreGroupWithRetry()` として `groupRestore.ts` に抽出
- update後に `chrome.tabGroups.get()` で検証し、title/colorが反映されていない場合は最大3回リトライする仕組みを追加

## Changes

- `src/manager/groupRestore.ts`: 新規モジュール。リトライ付きグループ復元ロジックを集約
- `src/manager/groupRestore.test.ts`: 正常系・リトライ・失敗系の包括的テスト
- `src/manager/ManagerApp.tsx`: インラインのグループ操作関数を削除し、`restoreGroupWithRetry()` に置き換え

## Test plan

- [x] `pnpm test` 全テスト通過
- [x] `pnpm check` (lint + format + typecheck) 通過
- [x] `pnpm build` 成功
- [ ] Chrome上でタブグループを含むウィンドウセットを復元し、グループ名が正しく表示されることを目視確認

Closes #20