### PR TITLE
fix: グループ復元時に復元先ウィンドウが考慮されないバグを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.pnpm-store
 dist
 dist-ssr
 *.local

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ node_modules
 dist
 pnpm-lock.yaml
 .tmp_scaffold
+.takt
+.pnpm-store

--- a/src/manager/ManagerApp.restoreGroup.test.ts
+++ b/src/manager/ManagerApp.restoreGroup.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import managerAppSource from './ManagerApp.tsx?raw';
+
+function getRestoreGroupHandlerSource() {
+  const start = managerAppSource.indexOf('const handleRestoreGroup = async');
+  const end = managerAppSource.indexOf('const handleRestoreTab = async', start);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return managerAppSource.slice(start, end);
+}
+
+describe('ManagerApp handleRestoreGroup', () => {
+  it('グループ復元先を現在の管理画面との紐づけ状態から判定する', () => {
+    const source = getRestoreGroupHandlerSource();
+
+    expect(source).toContain('const currentManager = await getCurrentManagerContext()');
+    expect(source).toContain('const restoreTarget = resolveRestoreTarget(');
+    expect(source).toContain('targetSet.managerBinding');
+    expect(source).toContain('currentManager.tabId');
+    expect(source).toContain('currentManager.windowId');
+    expect(source).toContain(
+      "const restoreWindow = restoreTarget === 'new-window' ? await createRestoreWindow() : null",
+    );
+    expect(source).not.toContain('getCurrentWindowId()');
+  });
+
+  it('bound-current は現在の管理画面ウィンドウ、unbound と bound-other は新規ウィンドウへ復元する', () => {
+    const source = getRestoreGroupHandlerSource();
+
+    expect(source).toContain('const windowId = restoreWindow?.windowId ?? currentManager.windowId');
+    expect(source).toContain('const baseTabIndex = await getWindowTabCount(windowId)');
+    expect(source).toContain('windowId');
+  });
+
+  it('復元対象タブがない場合は復元先ウィンドウの解決前に終了する', () => {
+    const source = getRestoreGroupHandlerSource();
+    const tabsIndex = source.indexOf(
+      'const tabs = targetSet.tabs.filter((tab) => tab.groupId === groupId)',
+    );
+    const emptyTabsIndex = source.indexOf('if (tabs.length === 0)');
+    const currentManagerIndex = source.indexOf(
+      'const currentManager = await getCurrentManagerContext()',
+    );
+    const createRestoreWindowIndex = source.indexOf('await createRestoreWindow()');
+    const getWindowTabCountIndex = source.indexOf('await getWindowTabCount(windowId)');
+
+    expect(tabsIndex).toBeGreaterThanOrEqual(0);
+    expect(emptyTabsIndex).toBeGreaterThan(tabsIndex);
+    expect(currentManagerIndex).toBeGreaterThan(emptyTabsIndex);
+    expect(createRestoreWindowIndex).toBeGreaterThan(emptyTabsIndex);
+    expect(getWindowTabCountIndex).toBeGreaterThan(emptyTabsIndex);
+  });
+
+  it('新規復元ウィンドウの初期タブをグループ復元後に削除する', () => {
+    const source = getRestoreGroupHandlerSource();
+    const restoreTabsIndex = source.indexOf(
+      'const { restoredTabs, failedTabs, sessionRestoredCount }',
+    );
+    const removeInitialTabIndex = source.indexOf(
+      'await removeInitialRestoreTab(restoreWindow.initialTabId)',
+    );
+    const cleanupIndex = source.indexOf('if (removeRestoredTabsEnabled)');
+
+    expect(restoreTabsIndex).toBeGreaterThanOrEqual(0);
+    expect(removeInitialTabIndex).toBeGreaterThan(restoreTabsIndex);
+    expect(cleanupIndex).toBeGreaterThan(removeInitialTabIndex);
+  });
+
+  it('初期タブ削除処理は共通ヘルパーに集約する', () => {
+    expect(managerAppSource).toContain(
+      'async function removeInitialRestoreTab(initialTabId: number | null)',
+    );
+    expect(managerAppSource).not.toContain('async function removeInitialRestoreTab(restoreWindow');
+    expect(managerAppSource).not.toContain('await removeInitialRestoreTab(restoreWindow)');
+    expect(managerAppSource).toContain(
+      "console.error('Failed to remove initial tab in restore window', err)",
+    );
+  });
+});

--- a/src/manager/ManagerApp.tsx
+++ b/src/manager/ManagerApp.tsx
@@ -1375,6 +1375,18 @@ async function createRestoreWindow() {
   });
 }
 
+async function removeInitialRestoreTab(initialTabId: number | null) {
+  if (initialTabId === null) {
+    return;
+  }
+
+  try {
+    await removeTab(initialTabId);
+  } catch (err) {
+    console.error('Failed to remove initial tab in restore window', err);
+  }
+}
+
 async function createMetadataRefreshWindow() {
   return new Promise<{ windowId: number; tabId: number }>((resolve, reject) => {
     chrome.windows.create({ focused: false }, (window: chrome.windows.Window | undefined) => {
@@ -2434,15 +2446,8 @@ export function ManagerApp() {
         restoreLoadingSuppressionEnabled,
         baseTabIndex,
       );
-      const initialTabId = restoreWindow?.initialTabId ?? null;
       if (restoreWindow) {
-        if (initialTabId !== null) {
-          try {
-            await removeTab(initialTabId);
-          } catch (err) {
-            console.error('Failed to remove initial tab in restore window', err);
-          }
-        }
+        await removeInitialRestoreTab(restoreWindow.initialTabId);
       }
       if (removeRestoredTabsEnabled) {
         const updated = await updateState((current) => ({
@@ -2487,13 +2492,20 @@ export function ManagerApp() {
     }
     setActionMessage('グループを復元しています...');
     try {
-      const windowId = await getCurrentWindowId();
-      const baseTabIndex = await getWindowTabCount(windowId);
       const tabs = targetSet.tabs.filter((tab) => tab.groupId === groupId);
       if (tabs.length === 0) {
         setActionMessage('復元できるタブがありません。');
         return;
       }
+      const currentManager = await getCurrentManagerContext();
+      const restoreTarget = resolveRestoreTarget(
+        targetSet.managerBinding,
+        currentManager.tabId,
+        currentManager.windowId,
+      );
+      const restoreWindow = restoreTarget === 'new-window' ? await createRestoreWindow() : null;
+      const windowId = restoreWindow?.windowId ?? currentManager.windowId;
+      const baseTabIndex = await getWindowTabCount(windowId);
       const { restoredTabs, failedTabs, sessionRestoredCount } = await restoreTabs(
         tabs,
         [group],
@@ -2501,6 +2513,9 @@ export function ManagerApp() {
         restoreLoadingSuppressionEnabled,
         baseTabIndex,
       );
+      if (restoreWindow) {
+        await removeInitialRestoreTab(restoreWindow.initialTabId);
+      }
       if (removeRestoredTabsEnabled) {
         const updated = await updateState((current) => ({
           ...current,


### PR DESCRIPTION
## Summary

- `handleRestoreGroup()` に `resolveRestoreTarget()` を適用し、`handleRestoreSet()` と同様にバインディング状態に基づいて新規ウィンドウ・既存ウィンドウを正しく選択するよう修正
- `removeInitialRestoreTab()` ヘルパーを抽出し、初期タブ削除ロジックを共通化
- グループ復元のテスト (`ManagerApp.restoreGroup.test.ts`) を追加
- `.gitignore` / `.prettierignore` に `.pnpm-store` と `.takt` を追加

Closes #22

## Test plan

- [ ] `pnpm test` でユニットテストが通ること
- [ ] `pnpm check` で lint / format / typecheck が通ること
- [ ] `pnpm build` でビルドが成功すること
- [ ] 未バインドのウィンドウセットからグループ復元 → 新規ウィンドウで復元されること
- [ ] バインド済みウィンドウセットからグループ復元 → 既存ウィンドウで復元されること