### PR TITLE
feat: 復元時に重複タブグループをマージする機能を追加

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
         with:
-          version: latest
+          version: 10.33.0
       - name: Install dependencies
         run: pnpm install
       - name: Run checks

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
         with:
-          version: latest
+          version: 10.33.0
       - name: Install dependencies
         run: pnpm install
       - name: Run checks

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "chrome-tab-manager",
   "private": true,
   "version": "1.1.1",
+  "packageManager": "pnpm@10.33.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/manager/ManagerApp.restoreGroup.test.ts
+++ b/src/manager/ManagerApp.restoreGroup.test.ts
@@ -56,9 +56,7 @@ describe('ManagerApp handleRestoreGroup', () => {
 
   it('新規復元ウィンドウの初期タブをグループ復元後に削除する', () => {
     const source = getRestoreGroupHandlerSource();
-    const restoreTabsIndex = source.indexOf(
-      'const { restoredTabs, failedTabs, sessionRestoredCount }',
-    );
+    const restoreTabsIndex = source.indexOf('await restoreTabs(');
     const removeInitialTabIndex = source.indexOf(
       'await removeInitialRestoreTab(restoreWindow.initialTabId)',
     );

--- a/src/manager/ManagerApp.tsx
+++ b/src/manager/ManagerApp.tsx
@@ -62,12 +62,11 @@ import {
   toggleTabLockWithPropagation,
 } from './lockState';
 import { cleanupHistorySet } from './restoreCleanup';
-import { shouldSuppressRestoreLoading } from './restorePolicy';
 import { resolveRestoreTarget } from './restoreTarget';
-import { restoreSession, moveTabToWindow, ungroupTab } from './sessionRestore';
 import { removeSetsEmptiedSince } from './setCleanup';
 import { matchesExpectedUrl } from './urlMatch';
-import { restoreGroupWithRetry } from './groupRestore';
+import { restoreTabs } from './restoreTabs';
+import { buildRestoreActionMessage } from './restoreActionMessage';
 import {
   getBindingStatusLabel,
   resolveBindingStatus,
@@ -1538,207 +1537,6 @@ async function waitForTabMetadata(
   });
 }
 
-async function createTab(windowId: number, url: string, index: number) {
-  return new Promise<chrome.tabs.Tab>((resolve, reject) => {
-    chrome.tabs.create({ windowId, url, active: false, index }, (tab: chrome.tabs.Tab) => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-        return;
-      }
-      resolve(tab);
-    });
-  });
-}
-
-async function discardTab(tabId: number) {
-  return new Promise<void>((resolve) => {
-    chrome.tabs.discard(tabId, () => {
-      if (chrome.runtime.lastError) {
-        console.warn('Failed to discard tab (non-blocking)', chrome.runtime.lastError);
-      }
-      resolve();
-    });
-  });
-}
-
-async function waitForTabUrl(tabId: number, expectedUrl: string, timeoutMs = 3000) {
-  return new Promise<boolean>((resolve) => {
-    let settled = false;
-    const finish = (matched: boolean) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeoutId);
-      chrome.tabs.onUpdated.removeListener(handleUpdated);
-      resolve(matched);
-    };
-
-    const handleUpdated = (
-      updatedTabId: number,
-      changeInfo: chrome.tabs.TabChangeInfo,
-      tab: chrome.tabs.Tab,
-    ) => {
-      if (updatedTabId !== tabId) {
-        return;
-      }
-      if (matchesExpectedUrl(expectedUrl, tab, changeInfo)) {
-        finish(true);
-      }
-    };
-
-    const timeoutId = setTimeout(() => {
-      console.debug('Discard wait timeout reached', { tabId, expectedUrl, timeoutMs });
-      finish(false);
-    }, timeoutMs);
-
-    chrome.tabs.onUpdated.addListener(handleUpdated);
-    chrome.tabs.get(tabId, (tab) => {
-      if (chrome.runtime.lastError || !tab) {
-        return;
-      }
-      if (matchesExpectedUrl(expectedUrl, tab)) {
-        finish(true);
-      }
-    });
-  });
-}
-
-async function restoreTabs(
-  tabs: TabSnapshot[],
-  groups: GroupSnapshot[],
-  windowId: number,
-  restoreLoadingSuppressionEnabled: boolean,
-  baseTabIndex: number,
-) {
-  const sortedTabs = [...tabs].sort((a, b) => a.index - b.index);
-  const shouldDiscard = shouldSuppressRestoreLoading({
-    enabled: restoreLoadingSuppressionEnabled,
-    tabCount: sortedTabs.length,
-  });
-
-  // Phase 0: sessionId ありのタブを sessions.restore() で復元
-  const sessionRestoredTabs: Array<{ snapshot: TabSnapshot; tab: chrome.tabs.Tab }> = [];
-  const fallbackTabs: TabSnapshot[] = [];
-  let sessionRestoredCount = 0;
-
-  for (const tab of sortedTabs) {
-    if (!tab.sessionId) {
-      fallbackTabs.push(tab);
-      continue;
-    }
-    try {
-      const session = await restoreSession(tab.sessionId);
-      if (!session.tab || session.tab.id === undefined) {
-        fallbackTabs.push(tab);
-        continue;
-      }
-      const restoredTab = session.tab;
-      sessionRestoredCount++;
-
-      try {
-        if (restoredTab.windowId !== windowId) {
-          await moveTabToWindow(restoredTab.id!, windowId, baseTabIndex + tab.index);
-        }
-      } catch (err) {
-        console.warn('Failed to move session-restored tab to target window', err);
-      }
-
-      try {
-        if (restoredTab.groupId !== undefined && restoredTab.groupId !== -1) {
-          await ungroupTab(restoredTab.id!);
-        }
-      } catch (err) {
-        console.warn('Failed to ungroup session-restored tab', err);
-      }
-
-      sessionRestoredTabs.push({ snapshot: tab, tab: restoredTab });
-    } catch (err) {
-      console.warn('Failed to restore session, falling back to createTab', err);
-      fallbackTabs.push(tab);
-    }
-  }
-
-  // Phase 1: sessionId なし + Phase 0 フォールバック分を createTab で並列作成
-  const creationResults = await Promise.allSettled(
-    fallbackTabs.map((tab) => createTab(windowId, tab.url, baseTabIndex + tab.index)),
-  );
-  const createdTabs: Array<{ snapshot: TabSnapshot; tab: chrome.tabs.Tab }> = [];
-  const failedTabs: TabSnapshot[] = [];
-  creationResults.forEach((result, index) => {
-    const snapshot = fallbackTabs[index];
-    if (!snapshot) {
-      return;
-    }
-    if (result.status === 'fulfilled') {
-      createdTabs.push({ snapshot, tab: result.value });
-      return;
-    }
-    console.error('Failed to create tab', result.reason);
-    failedTabs.push(snapshot);
-  });
-
-  // 全復元タブ = Phase 0 + Phase 1
-  const allRestoredTabs = [...sessionRestoredTabs, ...createdTabs];
-
-  // Phase 2: グループ復元
-  const groupTabIds = new Map<number, number[]>();
-  for (const { snapshot, tab } of allRestoredTabs) {
-    if (snapshot.groupId === null || tab.id === undefined) {
-      continue;
-    }
-    const list = groupTabIds.get(snapshot.groupId) ?? [];
-    list.push(tab.id);
-    groupTabIds.set(snapshot.groupId, list);
-  }
-
-  const sortedGroups = [...groups].sort((a, b) => a.index - b.index);
-  for (const group of sortedGroups) {
-    const tabIds = groupTabIds.get(group.id);
-    if (!tabIds || tabIds.length === 0) {
-      continue;
-    }
-    const newGroupId = await restoreGroupWithRetry(
-      windowId,
-      tabIds,
-      group.title,
-      group.color,
-      baseTabIndex + group.index,
-    );
-    if (newGroupId === null) {
-      continue;
-    }
-  }
-
-  // Phase 3: shouldDiscard 時のメモリ最適化
-  if (shouldDiscard) {
-    const restoredSnapshots = await Promise.all(
-      allRestoredTabs.map(async ({ snapshot, tab }) => {
-        if (tab.id === undefined) {
-          return snapshot;
-        }
-        const matched = await waitForTabUrl(tab.id, snapshot.url);
-        if (!matched) {
-          console.warn('Skip discard because tab url confirmation failed', {
-            tabId: tab.id,
-            expectedUrl: snapshot.url,
-          });
-          return snapshot;
-        }
-        await discardTab(tab.id);
-        return snapshot;
-      }),
-    );
-    return { restoredTabs: restoredSnapshots, failedTabs, sessionRestoredCount };
-  }
-
-  return {
-    restoredTabs: allRestoredTabs.map((item) => item.snapshot),
-    failedTabs,
-    sessionRestoredCount,
-  };
-}
-
 export function ManagerApp() {
   const optionsUrl = chrome.runtime.getURL('options.html');
   const [state, setState] = useState<{
@@ -2439,13 +2237,14 @@ export function ManagerApp() {
       const restoreWindow = restoreTarget === 'new-window' ? await createRestoreWindow() : null;
       const windowId = restoreWindow?.windowId ?? currentManager.windowId;
       const baseTabIndex = await getWindowTabCount(windowId);
-      const { restoredTabs, failedTabs, sessionRestoredCount } = await restoreTabs(
-        targetSet.tabs,
-        targetSet.groups,
-        windowId,
-        restoreLoadingSuppressionEnabled,
-        baseTabIndex,
-      );
+      const { restoredTabs, failedTabs, sessionRestoredCount, skippedDuplicateCount } =
+        await restoreTabs(
+          targetSet.tabs,
+          targetSet.groups,
+          windowId,
+          restoreLoadingSuppressionEnabled,
+          baseTabIndex,
+        );
       if (restoreWindow) {
         await removeInitialRestoreTab(restoreWindow.initialTabId);
       }
@@ -2463,19 +2262,16 @@ export function ManagerApp() {
         await refreshState(updated.historySets);
       }
       const total = targetSet.tabs.length;
-      if (failedTabs.length > 0) {
-        setActionMessage(
-          sessionRestoredCount > 0
-            ? `${total}件中${restoredTabs.length}件のタブを復元しました（${sessionRestoredCount}件が履歴付き）。`
-            : `${total}件中${restoredTabs.length}件のタブを復元しました。`,
-        );
-      } else if (sessionRestoredCount > 0 && sessionRestoredCount === total) {
-        setActionMessage(`タブを復元しました（全${total}件が履歴付き）。`);
-      } else if (sessionRestoredCount > 0) {
-        setActionMessage(`${total}件中${sessionRestoredCount}件が履歴付きで復元されました。`);
-      } else {
-        setActionMessage('タブを復元しました。');
-      }
+      setActionMessage(
+        buildRestoreActionMessage(
+          'タブ',
+          total,
+          restoredTabs.length,
+          failedTabs.length,
+          sessionRestoredCount,
+          skippedDuplicateCount,
+        ),
+      );
     } catch (err) {
       console.error('Failed to restore tabs', err);
       setActionMessage(
@@ -2506,13 +2302,8 @@ export function ManagerApp() {
       const restoreWindow = restoreTarget === 'new-window' ? await createRestoreWindow() : null;
       const windowId = restoreWindow?.windowId ?? currentManager.windowId;
       const baseTabIndex = await getWindowTabCount(windowId);
-      const { restoredTabs, failedTabs, sessionRestoredCount } = await restoreTabs(
-        tabs,
-        [group],
-        windowId,
-        restoreLoadingSuppressionEnabled,
-        baseTabIndex,
-      );
+      const { restoredTabs, failedTabs, sessionRestoredCount, skippedDuplicateCount } =
+        await restoreTabs(tabs, [group], windowId, restoreLoadingSuppressionEnabled, baseTabIndex);
       if (restoreWindow) {
         await removeInitialRestoreTab(restoreWindow.initialTabId);
       }
@@ -2529,19 +2320,16 @@ export function ManagerApp() {
         }));
         await refreshState(updated.historySets);
       }
-      if (failedTabs.length > 0) {
-        setActionMessage(
-          sessionRestoredCount > 0
-            ? `${tabs.length}件中${restoredTabs.length}件のタブを復元しました（${sessionRestoredCount}件が履歴付き）。`
-            : `${tabs.length}件中${restoredTabs.length}件のタブを復元しました。`,
-        );
-      } else if (sessionRestoredCount > 0 && sessionRestoredCount === tabs.length) {
-        setActionMessage(`グループを復元しました（全${tabs.length}件が履歴付き）。`);
-      } else if (sessionRestoredCount > 0) {
-        setActionMessage(`${tabs.length}件中${sessionRestoredCount}件が履歴付きで復元されました。`);
-      } else {
-        setActionMessage('グループを復元しました。');
-      }
+      setActionMessage(
+        buildRestoreActionMessage(
+          'グループ',
+          tabs.length,
+          restoredTabs.length,
+          failedTabs.length,
+          sessionRestoredCount,
+          skippedDuplicateCount,
+        ),
+      );
     } catch (err) {
       console.error('Failed to restore group', err);
       setActionMessage(err instanceof Error ? err.message : 'グループの復元に失敗しました。');
@@ -2553,7 +2341,7 @@ export function ManagerApp() {
     try {
       const windowId = await getCurrentWindowId();
       const baseTabIndex = await getWindowTabCount(windowId);
-      const { restoredTabs, sessionRestoredCount } = await restoreTabs(
+      const { restoredTabs, sessionRestoredCount, skippedDuplicateCount } = await restoreTabs(
         [tab],
         [],
         windowId,
@@ -2575,7 +2363,18 @@ export function ManagerApp() {
       }
       if (restoredTabs.length === 1) {
         setActionMessage(
-          sessionRestoredCount > 0 ? 'タブを復元しました（履歴付き）。' : 'タブを復元しました。',
+          skippedDuplicateCount > 0
+            ? buildRestoreActionMessage(
+                'タブ',
+                1,
+                restoredTabs.length,
+                0,
+                sessionRestoredCount,
+                skippedDuplicateCount,
+              )
+            : sessionRestoredCount > 0
+              ? 'タブを復元しました（履歴付き）。'
+              : 'タブを復元しました。',
         );
       } else {
         setActionMessage('タブの復元に失敗しました。');

--- a/src/manager/groupRestore.test.ts
+++ b/src/manager/groupRestore.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { restoreGroupWithRetry } from './groupRestore';
+import { addTabsToExistingGroup, restoreGroupWithRetry } from './groupRestore';
 
 type ChromeRuntimeState = {
   lastError: Error | null;
@@ -238,5 +238,42 @@ describe('restoreGroupWithRetry', () => {
 
     expect(result).toBe(91);
     expect(warnSpy).toHaveBeenCalledWith('Failed to move tab group', expect.any(Error));
+  });
+});
+
+describe('addTabsToExistingGroup', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('既存グループにタブを追加できる', async () => {
+    const { tabsGroup } = stubChrome();
+    tabsGroup.mockImplementation(
+      (_options: chrome.tabs.GroupOptions, callback: (groupId: number) => void) => {
+        callback(91);
+      },
+    );
+
+    await addTabsToExistingGroup(91, [10, 11]);
+
+    expect(tabsGroup).toHaveBeenCalledTimes(1);
+    expect(tabsGroup).toHaveBeenCalledWith({ groupId: 91, tabIds: [10, 11] }, expect.any(Function));
+  });
+
+  it('Chrome API エラー時にリジェクトする', async () => {
+    const { runtime, tabsGroup } = stubChrome();
+    const lastError = new Error('group failed');
+    tabsGroup.mockImplementation(
+      (_options: chrome.tabs.GroupOptions, callback: (groupId: number) => void) => {
+        runtime.lastError = lastError;
+        callback(-1);
+      },
+    );
+
+    await expect(addTabsToExistingGroup(91, [10, 11])).rejects.toBe(lastError);
   });
 });

--- a/src/manager/groupRestore.ts
+++ b/src/manager/groupRestore.ts
@@ -27,6 +27,18 @@ async function groupTabs(windowId: number, tabIds: number[]) {
   });
 }
 
+export async function addTabsToExistingGroup(groupId: number, tabIds: number[]) {
+  return new Promise<void>((resolve, reject) => {
+    chrome.tabs.group({ groupId, tabIds }, () => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
 async function updateTabGroup(groupId: number, title: string, color: chrome.tabGroups.ColorEnum) {
   return new Promise<void>((resolve, reject) => {
     chrome.tabGroups.update(groupId, { title, color }, () => {

--- a/src/manager/mergeRestore.test.ts
+++ b/src/manager/mergeRestore.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildMergeFilter, queryWindowTabState } from './mergeRestore';
+import type { GroupSnapshot, TabSnapshot } from '../tab-manager/types';
+
+function group(overrides: Partial<GroupSnapshot> & Pick<GroupSnapshot, 'id' | 'title'>) {
+  return {
+    uid: `group-${overrides.id}`,
+    id: overrides.id,
+    title: overrides.title,
+    color: overrides.color ?? 'blue',
+    index: overrides.index ?? 0,
+    locked: overrides.locked ?? false,
+  } satisfies GroupSnapshot;
+}
+
+function tab(overrides: Partial<TabSnapshot> & Pick<TabSnapshot, 'uid' | 'url'>) {
+  return {
+    uid: overrides.uid,
+    title: overrides.title ?? overrides.uid,
+    url: overrides.url,
+    index: overrides.index ?? 0,
+    groupId: overrides.groupId ?? null,
+    locked: overrides.locked ?? false,
+    sessionId: overrides.sessionId,
+  } satisfies TabSnapshot;
+}
+
+describe('queryWindowTabState', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('復元先ウィンドウの既存グループと全URLを収集する', async () => {
+    const tabGroupsQuery = vi.fn(
+      (
+        _queryInfo: chrome.tabGroups.QueryInfo,
+        callback: (groups: chrome.tabGroups.TabGroup[]) => void,
+      ) => {
+        callback([
+          { id: 10, title: 'Work', color: 'blue' },
+          { id: 11, title: 'Read', color: 'red' },
+        ] as chrome.tabGroups.TabGroup[]);
+      },
+    );
+    const tabsQuery = vi.fn(
+      (_queryInfo: chrome.tabs.QueryInfo, callback: (tabs: chrome.tabs.Tab[]) => void) => {
+        callback([
+          { id: 1, url: 'https://docs.example.com', groupId: 10 },
+          { id: 2, url: 'https://mail.example.com', groupId: 10 },
+          { id: 3, url: 'https://news.example.com', groupId: -1 },
+          { id: 4, url: 'https://empty.example.com' },
+        ] as chrome.tabs.Tab[]);
+      },
+    );
+    vi.stubGlobal('chrome', {
+      runtime: { lastError: null },
+      tabGroups: {
+        TAB_GROUP_ID_NONE: -1,
+        query: tabGroupsQuery,
+      },
+      tabs: {
+        query: tabsQuery,
+      },
+    });
+
+    const result = await queryWindowTabState(7);
+
+    expect(tabGroupsQuery).toHaveBeenCalledWith({ windowId: 7 }, expect.any(Function));
+    expect(tabsQuery).toHaveBeenCalledWith({ windowId: 7 }, expect.any(Function));
+    expect(result.groups).toHaveLength(2);
+    expect(result.groups[0]).toMatchObject({ groupId: 10, title: 'Work', color: 'blue' });
+    expect([...result.groups[0]!.urls]).toEqual([
+      'https://docs.example.com',
+      'https://mail.example.com',
+    ]);
+    expect([...result.groups[1]!.urls]).toEqual([]);
+    expect([...result.allUrls]).toEqual([
+      'https://docs.example.com',
+      'https://mail.example.com',
+      'https://news.example.com',
+      'https://empty.example.com',
+    ]);
+  });
+
+  it('Chrome API エラー時は例外を伝播する', async () => {
+    const lastError = new Error('tabGroups query failed');
+    const tabGroupsQuery = vi.fn(
+      (
+        _queryInfo: chrome.tabGroups.QueryInfo,
+        callback: (groups: chrome.tabGroups.TabGroup[]) => void,
+      ) => {
+        chrome.runtime.lastError = lastError;
+        callback([]);
+      },
+    );
+    const tabsQuery = vi.fn();
+    vi.stubGlobal('chrome', {
+      runtime: { lastError: null },
+      tabGroups: {
+        TAB_GROUP_ID_NONE: -1,
+        query: tabGroupsQuery,
+      },
+      tabs: {
+        query: tabsQuery,
+      },
+    });
+
+    await expect(queryWindowTabState(7)).rejects.toBe(lastError);
+    expect(tabsQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildMergeFilter', () => {
+  it('同名グループが存在する場合に mergeTargets にマッピングする', () => {
+    const tabs = [tab({ uid: 'tab-1', url: 'https://new.example.com', groupId: 1 })];
+    const groups = [group({ id: 1, title: 'Work' })];
+
+    const result = buildMergeFilter(tabs, groups, {
+      groups: [{ groupId: 10, title: 'Work', color: 'blue', urls: new Set() }],
+      allUrls: new Set(),
+    });
+
+    expect(result.mergeTargets.get(1)).toBe(10);
+    expect(result.tabsToRestore).toEqual(tabs);
+    expect(result.skippedTabs).toEqual([]);
+  });
+
+  it('同名グループが存在しない場合は全タブを復元対象に含める', () => {
+    const tabs = [tab({ uid: 'tab-1', url: 'https://docs.example.com', groupId: 1 })];
+    const groups = [group({ id: 1, title: 'Work' })];
+
+    const result = buildMergeFilter(tabs, groups, {
+      groups: [{ groupId: 10, title: 'Read', color: 'red', urls: new Set() }],
+      allUrls: new Set(),
+    });
+
+    expect(result.mergeTargets.size).toBe(0);
+    expect(result.tabsToRestore).toEqual(tabs);
+    expect(result.skippedTabs).toEqual([]);
+  });
+
+  it('マージ先グループ内に同一URLのタブがある場合はスキップする', () => {
+    const duplicate = tab({ uid: 'tab-1', url: 'https://docs.example.com', groupId: 1 });
+    const fresh = tab({ uid: 'tab-2', url: 'https://mail.example.com', groupId: 1 });
+
+    const result = buildMergeFilter([duplicate, fresh], [group({ id: 1, title: 'Work' })], {
+      groups: [
+        {
+          groupId: 10,
+          title: 'Work',
+          color: 'blue',
+          urls: new Set(['https://docs.example.com']),
+        },
+      ],
+      allUrls: new Set(['https://docs.example.com']),
+    });
+
+    expect(result.skippedTabs).toEqual([duplicate]);
+    expect(result.tabsToRestore).toEqual([fresh]);
+  });
+
+  it('マージ先グループ内にないURLのタブは復元対象に含める', () => {
+    const fresh = tab({ uid: 'tab-1', url: 'https://new.example.com', groupId: 1 });
+
+    const result = buildMergeFilter([fresh], [group({ id: 1, title: 'Work' })], {
+      groups: [
+        {
+          groupId: 10,
+          title: 'Work',
+          color: 'blue',
+          urls: new Set(['https://docs.example.com']),
+        },
+      ],
+      allUrls: new Set(['https://docs.example.com']),
+    });
+
+    expect(result.tabsToRestore).toEqual([fresh]);
+    expect(result.skippedTabs).toEqual([]);
+  });
+
+  it('未グループタブで同一URLが存在する場合はスキップする', () => {
+    const duplicate = tab({ uid: 'tab-1', url: 'https://news.example.com', groupId: null });
+
+    const result = buildMergeFilter([duplicate], [], {
+      groups: [],
+      allUrls: new Set(['https://news.example.com']),
+    });
+
+    expect(result.tabsToRestore).toEqual([]);
+    expect(result.skippedTabs).toEqual([duplicate]);
+  });
+
+  it('未グループタブは既存グループ内に同一URLがある場合もスキップする', () => {
+    const duplicate = tab({ uid: 'tab-1', url: 'https://docs.example.com', groupId: null });
+
+    const result = buildMergeFilter([duplicate], [], {
+      groups: [
+        {
+          groupId: 10,
+          title: 'Work',
+          color: 'blue',
+          urls: new Set(['https://docs.example.com']),
+        },
+      ],
+      allUrls: new Set(['https://docs.example.com']),
+    });
+
+    expect(result.tabsToRestore).toEqual([]);
+    expect(result.skippedTabs).toEqual([duplicate]);
+  });
+
+  it('未グループタブで同一URLが存在しない場合は復元対象に含める', () => {
+    const fresh = tab({ uid: 'tab-1', url: 'https://new.example.com', groupId: null });
+
+    const result = buildMergeFilter([fresh], [], {
+      groups: [],
+      allUrls: new Set(['https://news.example.com']),
+    });
+
+    expect(result.tabsToRestore).toEqual([fresh]);
+    expect(result.skippedTabs).toEqual([]);
+  });
+
+  it('空タイトルのグループはマージ対象にしない', () => {
+    const tabs = [tab({ uid: 'tab-1', url: 'https://docs.example.com', groupId: 1 })];
+    const groups = [group({ id: 1, title: '' })];
+
+    const result = buildMergeFilter(tabs, groups, {
+      groups: [{ groupId: 10, title: '', color: 'blue', urls: new Set() }],
+      allUrls: new Set(),
+    });
+
+    expect(result.mergeTargets.size).toBe(0);
+    expect(result.tabsToRestore).toEqual(tabs);
+  });
+
+  it('大文字小文字が異なるグループ名はマージしない', () => {
+    const tabs = [tab({ uid: 'tab-1', url: 'https://docs.example.com', groupId: 1 })];
+    const groups = [group({ id: 1, title: 'Work' })];
+
+    const result = buildMergeFilter(tabs, groups, {
+      groups: [{ groupId: 10, title: 'work', color: 'blue', urls: new Set() }],
+      allUrls: new Set(),
+    });
+
+    expect(result.mergeTargets.size).toBe(0);
+    expect(result.tabsToRestore).toEqual(tabs);
+  });
+
+  it('同名グループが複数ある場合は最初のグループにマッチする', () => {
+    const tabs = [tab({ uid: 'tab-1', url: 'https://docs.example.com', groupId: 1 })];
+    const groups = [group({ id: 1, title: 'Work' })];
+
+    const result = buildMergeFilter(tabs, groups, {
+      groups: [
+        { groupId: 10, title: 'Work', color: 'blue', urls: new Set() },
+        { groupId: 11, title: 'Work', color: 'red', urls: new Set() },
+      ],
+      allUrls: new Set(),
+    });
+
+    expect(result.mergeTargets.get(1)).toBe(10);
+  });
+
+  it('全タブがスキップされた場合に tabsToRestore が空になる', () => {
+    const groupedDuplicate = tab({
+      uid: 'tab-1',
+      url: 'https://docs.example.com',
+      groupId: 1,
+    });
+    const ungroupedDuplicate = tab({
+      uid: 'tab-2',
+      url: 'https://news.example.com',
+      groupId: null,
+    });
+
+    const result = buildMergeFilter(
+      [groupedDuplicate, ungroupedDuplicate],
+      [group({ id: 1, title: 'Work' })],
+      {
+        groups: [
+          {
+            groupId: 10,
+            title: 'Work',
+            color: 'blue',
+            urls: new Set(['https://docs.example.com']),
+          },
+        ],
+        allUrls: new Set(['https://docs.example.com', 'https://news.example.com']),
+      },
+    );
+
+    expect(result.tabsToRestore).toEqual([]);
+    expect(result.skippedTabs).toEqual([groupedDuplicate, ungroupedDuplicate]);
+  });
+});

--- a/src/manager/mergeRestore.ts
+++ b/src/manager/mergeRestore.ts
@@ -1,0 +1,118 @@
+import type { GroupSnapshot, TabSnapshot } from '../tab-manager/types';
+
+type ExistingGroupInfo = {
+  groupId: number;
+  title: string;
+  color: chrome.tabGroups.ColorEnum;
+  urls: Set<string>;
+};
+
+type WindowTabState = {
+  groups: ExistingGroupInfo[];
+  allUrls: Set<string>;
+};
+
+type MergeFilterResult = {
+  tabsToRestore: TabSnapshot[];
+  skippedTabs: TabSnapshot[];
+  mergeTargets: Map<number, number>;
+};
+
+function queryTabGroups(windowId: number) {
+  return new Promise<chrome.tabGroups.TabGroup[]>((resolve, reject) => {
+    chrome.tabGroups.query({ windowId }, (groups) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve(groups);
+    });
+  });
+}
+
+function queryTabs(windowId: number) {
+  return new Promise<chrome.tabs.Tab[]>((resolve, reject) => {
+    chrome.tabs.query({ windowId }, (tabs) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve(tabs);
+    });
+  });
+}
+
+export async function queryWindowTabState(windowId: number): Promise<WindowTabState> {
+  const tabGroups = await queryTabGroups(windowId);
+  const tabs = await queryTabs(windowId);
+  const groups = tabGroups.map((group) => ({
+    groupId: group.id,
+    title: group.title ?? '',
+    color: group.color,
+    urls: new Set<string>(),
+  }));
+  const groupsById = new Map(groups.map((group) => [group.groupId, group]));
+  const allUrls = new Set<string>();
+
+  for (const tab of tabs) {
+    if (!tab.url) {
+      continue;
+    }
+    allUrls.add(tab.url);
+    groupsById.get(tab.groupId)?.urls.add(tab.url);
+  }
+
+  return { groups, allUrls };
+}
+
+function buildMergeTargets(groups: GroupSnapshot[], windowState: WindowTabState) {
+  const mergeTargets = new Map<number, number>();
+  for (const group of groups) {
+    if (group.title === '') {
+      continue;
+    }
+    const existingGroup = windowState.groups.find((item) => item.title === group.title);
+    if (!existingGroup) {
+      continue;
+    }
+    mergeTargets.set(group.id, existingGroup.groupId);
+  }
+  return mergeTargets;
+}
+
+export function buildMergeFilter(
+  tabs: TabSnapshot[],
+  groups: GroupSnapshot[],
+  windowState: WindowTabState,
+): MergeFilterResult {
+  const mergeTargets = buildMergeTargets(groups, windowState);
+  const groupsById = new Map(windowState.groups.map((group) => [group.groupId, group]));
+  const tabsToRestore: TabSnapshot[] = [];
+  const skippedTabs: TabSnapshot[] = [];
+
+  for (const tab of tabs) {
+    if (tab.groupId === null) {
+      if (windowState.allUrls.has(tab.url)) {
+        skippedTabs.push(tab);
+        continue;
+      }
+      tabsToRestore.push(tab);
+      continue;
+    }
+
+    const mergeTargetGroupId = mergeTargets.get(tab.groupId);
+    if (mergeTargetGroupId === undefined) {
+      tabsToRestore.push(tab);
+      continue;
+    }
+
+    const mergeTarget = groupsById.get(mergeTargetGroupId);
+    if (mergeTarget?.urls.has(tab.url)) {
+      skippedTabs.push(tab);
+      continue;
+    }
+    tabsToRestore.push(tab);
+  }
+
+  return { tabsToRestore, skippedTabs, mergeTargets };
+}

--- a/src/manager/restoreActionMessage.test.ts
+++ b/src/manager/restoreActionMessage.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildRestoreActionMessage } from './restoreActionMessage';
+
+describe('buildRestoreActionMessage', () => {
+  it('重複スキップがあり失敗がない場合は既存タブとの重複数を表示する', () => {
+    const message = buildRestoreActionMessage('グループ', 3, 3, 0, 0, 2);
+
+    expect(message).toBe('グループを復元しました（2件は既存タブと重複のためスキップ）。');
+  });
+
+  it('重複スキップと失敗がある場合は作成またはセッション復元した件数を表示する', () => {
+    const message = buildRestoreActionMessage('タブ', 5, 4, 1, 1, 2);
+
+    expect(message).toBe('5件中2件のタブを復元しました（2件は重複スキップ）。');
+  });
+
+  it('重複スキップがなく履歴付き復元がある場合は履歴付き件数を表示する', () => {
+    const message = buildRestoreActionMessage('タブ', 4, 4, 0, 2, 0);
+
+    expect(message).toBe('4件中2件が履歴付きで復元されました。');
+  });
+
+  it('単一タブの重複スキップは既存タブとの重複として表示する', () => {
+    const message = buildRestoreActionMessage('タブ', 1, 1, 0, 0, 1);
+
+    expect(message).toBe('タブを復元しました（1件は既存タブと重複のためスキップ）。');
+  });
+});

--- a/src/manager/restoreActionMessage.ts
+++ b/src/manager/restoreActionMessage.ts
@@ -1,0 +1,30 @@
+type RestoreTargetLabel = 'タブ' | 'グループ';
+
+export function buildRestoreActionMessage(
+  targetLabel: RestoreTargetLabel,
+  total: number,
+  restoredCount: number,
+  failedCount: number,
+  sessionRestoredCount: number,
+  skippedDuplicateCount: number,
+) {
+  const createdOrSessionRestoredCount = restoredCount - skippedDuplicateCount;
+  if (failedCount > 0) {
+    if (skippedDuplicateCount > 0) {
+      return `${total}件中${createdOrSessionRestoredCount}件のタブを復元しました（${skippedDuplicateCount}件は重複スキップ）。`;
+    }
+    return sessionRestoredCount > 0
+      ? `${total}件中${restoredCount}件のタブを復元しました（${sessionRestoredCount}件が履歴付き）。`
+      : `${total}件中${restoredCount}件のタブを復元しました。`;
+  }
+  if (skippedDuplicateCount > 0) {
+    return `${targetLabel}を復元しました（${skippedDuplicateCount}件は既存タブと重複のためスキップ）。`;
+  }
+  if (sessionRestoredCount > 0 && sessionRestoredCount === total) {
+    return `${targetLabel}を復元しました（全${total}件が履歴付き）。`;
+  }
+  if (sessionRestoredCount > 0) {
+    return `${total}件中${sessionRestoredCount}件が履歴付きで復元されました。`;
+  }
+  return `${targetLabel}を復元しました。`;
+}

--- a/src/manager/restoreTabs.test.ts
+++ b/src/manager/restoreTabs.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { GroupSnapshot, TabSnapshot } from '../tab-manager/types';
+import { restoreTabs } from './restoreTabs';
+
+function group(overrides: Partial<GroupSnapshot> & Pick<GroupSnapshot, 'id' | 'title'>) {
+  return {
+    uid: `group-${overrides.id}`,
+    id: overrides.id,
+    title: overrides.title,
+    color: overrides.color ?? 'blue',
+    index: overrides.index ?? 0,
+    locked: overrides.locked ?? false,
+  } satisfies GroupSnapshot;
+}
+
+function tab(overrides: Partial<TabSnapshot> & Pick<TabSnapshot, 'uid' | 'url'>) {
+  return {
+    uid: overrides.uid,
+    title: overrides.title ?? overrides.uid,
+    url: overrides.url,
+    index: overrides.index ?? 0,
+    groupId: overrides.groupId ?? null,
+    locked: overrides.locked ?? false,
+    sessionId: overrides.sessionId,
+  } satisfies TabSnapshot;
+}
+
+describe('restoreTabs', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('既存同名グループへマージし、重複URLは作成せず復元済みに含める', async () => {
+    const existingGroupedDuplicate = tab({
+      uid: 'tab-duplicate-grouped',
+      url: 'https://docs.example.com',
+      groupId: 1,
+      index: 0,
+    });
+    const groupedFresh = tab({
+      uid: 'tab-fresh-grouped',
+      url: 'https://mail.example.com',
+      groupId: 1,
+      index: 1,
+    });
+    const existingUngroupedDuplicate = tab({
+      uid: 'tab-duplicate-ungrouped',
+      url: 'https://news.example.com',
+      groupId: null,
+      index: 2,
+    });
+    const ungroupedFresh = tab({
+      uid: 'tab-fresh-ungrouped',
+      url: 'https://new.example.com',
+      groupId: null,
+      index: 3,
+    });
+    const tabs = [
+      existingGroupedDuplicate,
+      groupedFresh,
+      existingUngroupedDuplicate,
+      ungroupedFresh,
+    ];
+    const groups = [group({ id: 1, title: 'Work', index: 0 })];
+    const runtime = { lastError: null as Error | null };
+    const tabGroupsQuery = vi.fn(
+      (
+        _queryInfo: chrome.tabGroups.QueryInfo,
+        callback: (groups: chrome.tabGroups.TabGroup[]) => void,
+      ) => {
+        callback([{ id: 10, title: 'Work', color: 'blue' }] as chrome.tabGroups.TabGroup[]);
+      },
+    );
+    const tabsQuery = vi.fn(
+      (_queryInfo: chrome.tabs.QueryInfo, callback: (tabs: chrome.tabs.Tab[]) => void) => {
+        callback([
+          { id: 101, url: 'https://docs.example.com', groupId: 10 },
+          { id: 102, url: 'https://news.example.com', groupId: -1 },
+        ] as chrome.tabs.Tab[]);
+      },
+    );
+    const tabsCreate = vi
+      .fn()
+      .mockImplementationOnce(
+        (_options: chrome.tabs.CreateProperties, callback: (tab: chrome.tabs.Tab) => void) => {
+          callback({ id: 201, url: 'https://mail.example.com', windowId: 7 } as chrome.tabs.Tab);
+        },
+      )
+      .mockImplementationOnce(
+        (_options: chrome.tabs.CreateProperties, callback: (tab: chrome.tabs.Tab) => void) => {
+          callback({ id: 202, url: 'https://new.example.com', windowId: 7 } as chrome.tabs.Tab);
+        },
+      );
+    const tabsGroup = vi.fn(
+      (_options: chrome.tabs.GroupOptions, callback: (groupId: number) => void) => {
+        callback(10);
+      },
+    );
+
+    vi.stubGlobal('chrome', {
+      runtime,
+      tabGroups: {
+        TAB_GROUP_ID_NONE: -1,
+        query: tabGroupsQuery,
+      },
+      tabs: {
+        query: tabsQuery,
+        create: tabsCreate,
+        group: tabsGroup,
+      },
+    });
+
+    const result = await restoreTabs(tabs, groups, 7, false, 4);
+
+    expect(tabGroupsQuery).toHaveBeenCalledWith({ windowId: 7 }, expect.any(Function));
+    expect(tabsQuery).toHaveBeenCalledWith({ windowId: 7 }, expect.any(Function));
+    expect(tabsCreate).toHaveBeenCalledTimes(2);
+    expect(tabsCreate).toHaveBeenNthCalledWith(
+      1,
+      { windowId: 7, url: 'https://mail.example.com', active: false, index: 5 },
+      expect.any(Function),
+    );
+    expect(tabsCreate).toHaveBeenNthCalledWith(
+      2,
+      { windowId: 7, url: 'https://new.example.com', active: false, index: 7 },
+      expect.any(Function),
+    );
+    expect(tabsGroup).toHaveBeenCalledTimes(1);
+    expect(tabsGroup).toHaveBeenCalledWith({ groupId: 10, tabIds: [201] }, expect.any(Function));
+    expect(result).toEqual({
+      restoredTabs: [
+        groupedFresh,
+        ungroupedFresh,
+        existingGroupedDuplicate,
+        existingUngroupedDuplicate,
+      ],
+      failedTabs: [],
+      sessionRestoredCount: 0,
+      skippedDuplicateCount: 2,
+    });
+  });
+});

--- a/src/manager/restoreTabs.ts
+++ b/src/manager/restoreTabs.ts
@@ -1,0 +1,224 @@
+import type { GroupSnapshot, TabSnapshot } from '../tab-manager/types';
+import { addTabsToExistingGroup, restoreGroupWithRetry } from './groupRestore';
+import { buildMergeFilter, queryWindowTabState } from './mergeRestore';
+import { shouldSuppressRestoreLoading } from './restorePolicy';
+import { restoreSession, moveTabToWindow, ungroupTab } from './sessionRestore';
+import { matchesExpectedUrl } from './urlMatch';
+
+async function createTab(windowId: number, url: string, index: number) {
+  return new Promise<chrome.tabs.Tab>((resolve, reject) => {
+    chrome.tabs.create({ windowId, url, active: false, index }, (tab: chrome.tabs.Tab) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve(tab);
+    });
+  });
+}
+
+async function discardTab(tabId: number) {
+  return new Promise<void>((resolve) => {
+    chrome.tabs.discard(tabId, () => {
+      if (chrome.runtime.lastError) {
+        console.warn('Failed to discard tab (non-blocking)', chrome.runtime.lastError);
+      }
+      resolve();
+    });
+  });
+}
+
+async function waitForTabUrl(tabId: number, expectedUrl: string, timeoutMs = 3000) {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (matched: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutId);
+      chrome.tabs.onUpdated.removeListener(handleUpdated);
+      resolve(matched);
+    };
+
+    const handleUpdated = (
+      updatedTabId: number,
+      changeInfo: chrome.tabs.TabChangeInfo,
+      tab: chrome.tabs.Tab,
+    ) => {
+      if (updatedTabId !== tabId) {
+        return;
+      }
+      if (matchesExpectedUrl(expectedUrl, tab, changeInfo)) {
+        finish(true);
+      }
+    };
+
+    const timeoutId = setTimeout(() => {
+      console.debug('Discard wait timeout reached', { tabId, expectedUrl, timeoutMs });
+      finish(false);
+    }, timeoutMs);
+
+    chrome.tabs.onUpdated.addListener(handleUpdated);
+    chrome.tabs.get(tabId, (tab) => {
+      if (chrome.runtime.lastError || !tab) {
+        return;
+      }
+      if (matchesExpectedUrl(expectedUrl, tab)) {
+        finish(true);
+      }
+    });
+  });
+}
+
+export async function restoreTabs(
+  tabs: TabSnapshot[],
+  groups: GroupSnapshot[],
+  windowId: number,
+  restoreLoadingSuppressionEnabled: boolean,
+  baseTabIndex: number,
+) {
+  const windowState = await queryWindowTabState(windowId);
+  const { tabsToRestore, skippedTabs, mergeTargets } = buildMergeFilter(tabs, groups, windowState);
+  const sortedTabs = [...tabsToRestore].sort((a, b) => a.index - b.index);
+  const shouldDiscard = shouldSuppressRestoreLoading({
+    enabled: restoreLoadingSuppressionEnabled,
+    tabCount: sortedTabs.length,
+  });
+
+  const sessionRestoredTabs: Array<{ snapshot: TabSnapshot; tab: chrome.tabs.Tab }> = [];
+  const fallbackTabs: TabSnapshot[] = [];
+  let sessionRestoredCount = 0;
+
+  for (const tab of sortedTabs) {
+    if (!tab.sessionId) {
+      fallbackTabs.push(tab);
+      continue;
+    }
+    try {
+      const session = await restoreSession(tab.sessionId);
+      const restoredTab = session.tab;
+      if (!restoredTab) {
+        fallbackTabs.push(tab);
+        continue;
+      }
+      const restoredTabId = restoredTab.id;
+      if (restoredTabId === undefined) {
+        fallbackTabs.push(tab);
+        continue;
+      }
+      sessionRestoredCount++;
+
+      try {
+        if (restoredTab.windowId !== windowId) {
+          await moveTabToWindow(restoredTabId, windowId, baseTabIndex + tab.index);
+        }
+      } catch (err) {
+        console.warn('Failed to move session-restored tab to target window', err);
+      }
+
+      try {
+        if (restoredTab.groupId !== undefined && restoredTab.groupId !== -1) {
+          await ungroupTab(restoredTabId);
+        }
+      } catch (err) {
+        console.warn('Failed to ungroup session-restored tab', err);
+      }
+
+      sessionRestoredTabs.push({ snapshot: tab, tab: restoredTab });
+    } catch (err) {
+      console.warn('Failed to restore session, falling back to createTab', err);
+      fallbackTabs.push(tab);
+    }
+  }
+
+  const creationResults = await Promise.allSettled(
+    fallbackTabs.map((tab) => createTab(windowId, tab.url, baseTabIndex + tab.index)),
+  );
+  const createdTabs: Array<{ snapshot: TabSnapshot; tab: chrome.tabs.Tab }> = [];
+  const failedTabs: TabSnapshot[] = [];
+  creationResults.forEach((result, index) => {
+    const snapshot = fallbackTabs[index];
+    if (!snapshot) {
+      return;
+    }
+    if (result.status === 'fulfilled') {
+      createdTabs.push({ snapshot, tab: result.value });
+      return;
+    }
+    console.error('Failed to create tab', result.reason);
+    failedTabs.push(snapshot);
+  });
+
+  const allRestoredTabs = [...sessionRestoredTabs, ...createdTabs];
+
+  const groupTabIds = new Map<number, number[]>();
+  for (const { snapshot, tab } of allRestoredTabs) {
+    if (snapshot.groupId === null || tab.id === undefined) {
+      continue;
+    }
+    const list = groupTabIds.get(snapshot.groupId) ?? [];
+    list.push(tab.id);
+    groupTabIds.set(snapshot.groupId, list);
+  }
+
+  const sortedGroups = [...groups].sort((a, b) => a.index - b.index);
+  for (const group of sortedGroups) {
+    const tabIds = groupTabIds.get(group.id);
+    if (!tabIds || tabIds.length === 0) {
+      continue;
+    }
+    const mergeTargetGroupId = mergeTargets.get(group.id);
+    if (mergeTargetGroupId !== undefined) {
+      try {
+        await addTabsToExistingGroup(mergeTargetGroupId, tabIds);
+      } catch (err) {
+        console.warn('Failed to add tabs to existing tab group', err);
+      }
+      continue;
+    }
+    const newGroupId = await restoreGroupWithRetry(
+      windowId,
+      tabIds,
+      group.title,
+      group.color,
+      baseTabIndex + group.index,
+    );
+    if (newGroupId === null) {
+      continue;
+    }
+  }
+
+  if (shouldDiscard) {
+    const restoredSnapshots = await Promise.all(
+      allRestoredTabs.map(async ({ snapshot, tab }) => {
+        if (tab.id === undefined) {
+          return snapshot;
+        }
+        const matched = await waitForTabUrl(tab.id, snapshot.url);
+        if (!matched) {
+          console.warn('Skip discard because tab url confirmation failed', {
+            tabId: tab.id,
+            expectedUrl: snapshot.url,
+          });
+          return snapshot;
+        }
+        await discardTab(tab.id);
+        return snapshot;
+      }),
+    );
+    return {
+      restoredTabs: [...restoredSnapshots, ...skippedTabs],
+      failedTabs,
+      sessionRestoredCount,
+      skippedDuplicateCount: skippedTabs.length,
+    };
+  }
+
+  return {
+    restoredTabs: [...allRestoredTabs.map((item) => item.snapshot), ...skippedTabs],
+    failedTabs,
+    sessionRestoredCount,
+    skippedDuplicateCount: skippedTabs.length,
+  };
+}


### PR DESCRIPTION
## Summary

- `mergeRestore.ts`: 既存ウィンドウの状態を収集し、重複タブ・グループを検出してマージ先を決定するロジックを実装
- `restoreTabs.ts`: タブ復元フローをモジュール化し、mergeRestore との連携により重複タブのスキップ・グループへのマージを実現
- `restoreActionMessage.ts`: 復元アクション結果メッセージの生成を分離
- `groupRestore.ts`: 既存グループへのタブ追加 `addTabsToExistingGroup` を追加
- `ManagerApp.tsx`: 旧インライン実装を削除し `restoreTabs` / `buildRestoreActionMessage` に委譲

Closes #21

## Test plan

- [ ] `pnpm test` でユニットテストが通ること
- [ ] `pnpm check` で lint / format / typecheck が通ること
- [ ] `pnpm build` でビルドが成功すること
- [ ] 復元先ウィンドウに同名タブグループがある場合、マージされること
- [ ] 同名グループ内に同一URLのタブがある場合、重複がスキップされること
- [ ] 未グループタブの同一URL重複もスキップされること